### PR TITLE
홈 화면 수정

### DIFF
--- a/FarmMate/bun.lock
+++ b/FarmMate/bun.lock
@@ -77,6 +77,7 @@
         "@vitejs/plugin-react": "^4.3.2",
         "autoprefixer": "^10.4.20",
         "concurrently": "^9.2.0",
+        "cross-env": "^10.0.0",
         "drizzle-kit": "^0.30.4",
         "esbuild": "^0.25.0",
         "postcss": "^8.4.47",
@@ -134,6 +135,8 @@
     "@babel/types": ["@babel/types@7.26.9", "", { "dependencies": { "@babel/helper-string-parser": "^7.25.9", "@babel/helper-validator-identifier": "^7.25.9" } }, "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@epic-web/invariant": ["@epic-web/invariant@1.0.0", "", {}, "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -538,6 +541,8 @@
     "cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
 
     "cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
+
+    "cross-env": ["cross-env@10.0.0", "", { "dependencies": { "@epic-web/invariant": "^1.0.0", "cross-spawn": "^7.0.6" }, "bin": { "cross-env": "dist/bin/cross-env.js", "cross-env-shell": "dist/bin/cross-env-shell.js" } }, "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/FarmMate/client/src/components/add-crop-dialog.tsx
+++ b/FarmMate/client/src/components/add-crop-dialog.tsx
@@ -26,8 +26,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
-import { insertCropSchema } from "@shared/schema";
-import type { InsertCrop, Crop } from "@shared/schema";
+import { insertCropSchema } from "../../../shared/schema";
+import type { InsertCrop, Crop } from "../../../shared/schema";
 import { apiRequest } from "@/lib/queryClient";
 import { z } from "zod";
 import { Search, Check } from "lucide-react";
@@ -166,7 +166,7 @@ export default function AddCropDialog({ open, onOpenChange, crop }: AddCropDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+              <DialogContent className="sm:max-w-[425px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {crop ? "작물 수정하기" : "작물을 선택해 주세요"}
@@ -269,13 +269,15 @@ export default function AddCropDialog({ open, onOpenChange, crop }: AddCropDialo
               )}
             />
 
-            <Button 
-              type="submit" 
-              className="w-full"
-              disabled={createMutation.isPending || updateMutation.isPending || !selectedCrop}
-            >
-              {createMutation.isPending || updateMutation.isPending ? "저장 중..." : "저장하기"}
-            </Button>
+            <div className="sticky bottom-0 bg-white pt-4 border-t">
+              <Button 
+                type="submit" 
+                className="w-full"
+                disabled={createMutation.isPending || updateMutation.isPending || !selectedCrop}
+              >
+                {createMutation.isPending || updateMutation.isPending ? "저장 중..." : "저장하기"}
+              </Button>
+            </div>
           </form>
         </Form>
       </DialogContent>

--- a/FarmMate/client/src/components/add-farm-dialog.tsx
+++ b/FarmMate/client/src/components/add-farm-dialog.tsx
@@ -122,7 +122,7 @@ export default function AddFarmDialog({ open, onOpenChange, farm }: AddFarmDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+              <DialogContent className="sm:max-w-[425px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {farm ? "농장 수정하기" : "농장을 선택해 주세요"}
@@ -220,13 +220,15 @@ export default function AddFarmDialog({ open, onOpenChange, farm }: AddFarmDialo
               )}
             />
 
-            <Button 
-              type="submit" 
-              className="w-full"
-              disabled={createMutation.isPending || updateMutation.isPending}
-            >
-              {createMutation.isPending || updateMutation.isPending ? "저장 중..." : "저장하기"}
-            </Button>
+            <div className="sticky bottom-0 bg-white pt-4 border-t">
+              <Button 
+                type="submit" 
+                className="w-full"
+                disabled={createMutation.isPending || updateMutation.isPending}
+              >
+                {createMutation.isPending || updateMutation.isPending ? "저장 중..." : "저장하기"}
+              </Button>
+            </div>
           </form>
         </Form>
       </DialogContent>

--- a/FarmMate/client/src/components/add-task-dialog-improved.tsx
+++ b/FarmMate/client/src/components/add-task-dialog-improved.tsx
@@ -1,21 +1,20 @@
 import { useState, useEffect } from "react";
 import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
-import { Calendar, CalendarIcon, Check, Search, Calculator, ChevronDown } from "lucide-react";
+import { CalendarIcon, Check, Search, Calculator, ChevronDown } from "lucide-react";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@shared/ui/button";
+import { Input } from "@shared/ui/input";
+import { Label } from "@shared/ui/label";
+import { Textarea } from "@shared/ui/textarea";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
+} from "@shared/ui/dialog";
 import {
   Form,
   FormControl,
@@ -23,37 +22,113 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@/components/ui/form";
+} from "@shared/ui/form";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
+} from "@shared/ui/select";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/ui/popover";
+} from "@shared/ui/popover";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { useToast } from "@/hooks/use-toast";
-import { insertTaskSchema } from "../shared/types/schema";
-import type { InsertTask, Task, Farm, Crop } from "../shared/types/schema";
-import { apiRequest } from "@/lib/queryClient";
-import WorkCalculatorDialog from "./work-calculator-dialog";
-import { KEY_CROPS, TASK_TYPES } from "@/shared/constants/crops";
+} from "@shared/ui/collapsible";
+import { useToast } from "@shared/hooks/use-toast";
+import { insertTaskSchema } from "../../../shared/schema";
+import type { InsertTask, Task, Farm, Crop } from "../../../shared/schema";
+import { apiRequest } from "@shared/api/client";
 import { z } from "zod";
+import { Calendar } from "@shared/ui/calendar";
+import WorkCalculatorDialog from "./work-calculator-dialog";
 
 const formSchema = insertTaskSchema.extend({
-  title: z.string().optional(),
-  environment: z.string().optional(),
-  taskType: z.string().optional(),
+  title: z.string().min(1, "제목을 입력해주세요"),
+  environment: z.string().min(1, "재배환경을 선택해주세요"),
 });
+
+// 핵심 작물 목록
+const KEY_CROPS = [
+  {
+    category: "배추",
+    name: "미니양배추",
+    variety: "디아라",
+    description: "작은 크기의 양배추로 가정에서 재배하기 좋음"
+  },
+  {
+    category: "배추",
+    name: "미니양배추", 
+    variety: "티아라",
+    description: "티아라 품종의 미니 양배추"
+  },
+  {
+    category: "배추",
+    name: "콜라비",
+    variety: "그린",
+    description: "줄기 부분을 먹는 배추과 채소"
+  },
+  {
+    category: "배추",
+    name: "콜라비",
+    variety: "퍼플",
+    description: "보라색 줄기의 콜라비"
+  },
+  {
+    category: "뿌리채소",
+    name: "당근",
+    variety: "오렌지",
+    description: "주황색 당근"
+  },
+  {
+    category: "뿌리채소", 
+    name: "비트",
+    variety: "레드",
+    description: "붉은색 비트"
+  },
+  {
+    category: "뿌리채소",
+    name: "무",
+    variety: "백무",
+    description: "흰색 무"
+  },
+  {
+    category: "잎채소",
+    name: "상추",
+    variety: "청상추",
+    description: "녹색 상추"
+  },
+  {
+    category: "잎채소",
+    name: "시금치",
+    variety: "일반",
+    description: "영양이 풍부한 시금치"
+  },
+  {
+    category: "과채류",
+    name: "토마토",
+    variety: "체리",
+    description: "작은 체리 토마토"
+  },
+  {
+    category: "과채류",
+    name: "고추",
+    variety: "청양고추",
+    description: "매운 청양고추"
+  }
+];
+
+const taskTypes = [
+  "파종", "육묘", "이랑준비", "정식", "풀/병해충/수분 관리", 
+  "고르기", "수확-선별", "저장-포장"
+];
+
+const environments = ["노지", "시설1", "시설2"];
 
 interface AddTaskDialogProps {
   open: boolean;
@@ -70,7 +145,6 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
   const [cropSearchTerm, setCropSearchTerm] = useState("");
   const [customCropName, setCustomCropName] = useState("");
   const [showKeyCrops, setShowKeyCrops] = useState(false);
-  const [dateRange, setDateRange] = useState({ from: "", to: "" });
   const [showWorkCalculator, setShowWorkCalculator] = useState(false);
   const [selectedCrop, setSelectedCrop] = useState<Crop | null>(null);
 
@@ -82,7 +156,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
     queryKey: ["/api/crops"],
   });
 
-  const form = useForm<InsertTask & { title: string; environment: string }>({
+  const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
       title: "",
@@ -91,10 +165,18 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
       scheduledDate: selectedDate || "",
       farmId: "",
       cropId: "",
-      userId: "user-1",
       environment: "",
     },
   });
+
+  // 제목 자동 설정
+  useEffect(() => {
+    const taskType = form.getValues("taskType");
+    if (cropSearchTerm && taskType) {
+      const autoTitle = `${cropSearchTerm}_${taskType}`;
+      form.setValue("title", autoTitle);
+    }
+  }, [cropSearchTerm, form]);
 
   // 태스크 수정 모드인 경우 초기값 설정
   useEffect(() => {
@@ -109,13 +191,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
         scheduledDate: task.scheduledDate,
         farmId: task.farmId,
         cropId: task.cropId,
-        userId: task.userId,
         environment: farm?.environment || "",
-      });
-      
-      setDateRange({
-        from: task.scheduledDate,
-        to: task.scheduledDate
       });
       
       if (crop) {
@@ -123,7 +199,6 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
         setSelectedCrop(crop);
       }
     } else if (!task && open) {
-      // 새 태스크 모드
       form.reset({
         title: "",
         description: "",
@@ -131,12 +206,8 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
         scheduledDate: selectedDate || "",
         farmId: "",
         cropId: "",
-        userId: "user-1",
         environment: "",
       });
-      
-      const today = selectedDate || format(new Date(), "yyyy-MM-dd");
-      setDateRange({ from: today, to: today });
       setCropSearchTerm("");
       setCustomCropName("");
       setSelectedWorks([]);
@@ -144,36 +215,16 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
     }
   }, [task, open, selectedDate, crops, farms, form]);
 
-  // 제목 자동 설정
-  useEffect(() => {
-    const taskType = form.getValues("taskType");
-    if (cropSearchTerm && taskType) {
-      const autoTitle = `${cropSearchTerm}_${taskType}`;
-      form.setValue("title", autoTitle);
-    }
-  }, [cropSearchTerm, form]);
-
   const createMutation = useMutation({
-    mutationFn: (data: InsertTask) => {
-      console.log("Creating task with data:", data);
-      return apiRequest("POST", "/api/tasks", data);
-    },
+    mutationFn: (data: InsertTask) => 
+      apiRequest("POST", "/api/tasks", data),
     onSuccess: () => {
-      console.log("Task created successfully");
       queryClient.invalidateQueries({ queryKey: ["/api/tasks"] });
       toast({
         title: "일정이 등록되었습니다.",
         description: "새로운 작업 일정이 추가되었습니다.",
       });
       onOpenChange(false);
-    },
-    onError: (error) => {
-      console.error("Failed to create task:", error);
-      toast({
-        title: "오류가 발생했습니다",
-        description: "작업 등록에 실패했습니다. 다시 시도해주세요.",
-        variant: "destructive",
-      });
     },
   });
 
@@ -191,28 +242,17 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
   });
 
   const bulkCreateMutation = useMutation({
-    mutationFn: (tasks: InsertTask[]) => {
-      console.log("Creating bulk tasks with data:", tasks);
-      return Promise.all(tasks.map(task => 
+    mutationFn: (tasks: InsertTask[]) => 
+      Promise.all(tasks.map(task => 
         apiRequest("POST", "/api/tasks", task)
-      ));
-    },
+      )),
     onSuccess: () => {
-      console.log("Bulk tasks created successfully");
       queryClient.invalidateQueries({ queryKey: ["/api/tasks"] });
       toast({
         title: "일정이 등록되었습니다.",
         description: "작업 일정이 추가되었습니다.",
       });
       onOpenChange(false);
-    },
-    onError: (error) => {
-      console.error("Failed to create bulk tasks:", error);
-      toast({
-        title: "오류가 발생했습니다",
-        description: "작업 등록에 실패했습니다. 다시 시도해주세요.",
-        variant: "destructive",
-      });
     },
   });
 
@@ -259,136 +299,45 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
     form.setValue("cropId", ""); // 커스텀 작물인 경우 cropId는 빈 값
   };
 
-  // 개별 등록 - 날짜 범위 내 모든 날짜에 작업 생성
-  const createIndividualTasks = () => {
-    console.log("createIndividualTasks called");
-    console.log("Date range:", dateRange);
-
-    const startDate = new Date(dateRange.from);
-    const endDate = new Date(dateRange.to);
-    const tasks: InsertTask[] = [];
-    
-    const taskType = form.getValues("taskType");
-    const cropName = customCropName || crops?.find(c => c.id === form.getValues("cropId"))?.name || "작물";
-    
-    console.log("Creating tasks for date range:", { startDate, endDate, taskType, cropName });
-    
-    // 날짜 범위 내 모든 날짜에 대해 작업 생성
-    for (let date = new Date(startDate); date <= endDate; date.setDate(date.getDate() + 1)) {
-      const dateStr = format(date, "yyyy-MM-dd");
-      const task = {
-        title: form.getValues("title") || `${cropName} ${taskType}`,
-        description: form.getValues("description") || `개별 등록으로 생성된 ${taskType} 작업`,
-        taskType: taskType,
-        scheduledDate: dateStr,
-        farmId: form.getValues("farmId"),
-        cropId: form.getValues("cropId"),
-        userId: "user-1",
-      };
-      tasks.push(task);
-      console.log("Created task:", task);
-    }
-
-    console.log("Total tasks to create:", tasks.length);
-    bulkCreateMutation.mutate(tasks);
-  };
-
   // 일괄 등록 - 여러 작업을 한 날짜에 등록
   const createBatchTasks = () => {
-    console.log("createBatchTasks called");
-    console.log("Selected works:", selectedWorks);
+    if (selectedWorks.length === 0) {
+      toast({
+        title: "작업을 선택해주세요",
+        variant: "destructive",
+      });
+      return;
+    }
 
     const cropName = customCropName || crops?.find(c => c.id === form.getValues("cropId"))?.name || "작물";
-    const tasks = selectedWorks.map(work => {
-      const task = {
-        title: form.getValues("title") || `${cropName} ${work}`,
-        description: form.getValues("description") || `일괄 등록으로 생성된 ${work} 작업`,
-        taskType: work,
-        scheduledDate: form.getValues("scheduledDate"),
-        farmId: form.getValues("farmId"),
-        cropId: form.getValues("cropId"),
-        userId: "user-1",
-      };
-      console.log("Created batch task:", task);
-      return task;
-    });
+    const tasks = selectedWorks.map(work => ({
+      title: form.getValues("title") || `${cropName} ${work}`,
+      description: form.getValues("description") || `일괄 등록으로 생성된 ${work} 작업`,
+      taskType: work,
+      scheduledDate: form.getValues("scheduledDate"),
+      farmId: form.getValues("farmId"),
+      cropId: form.getValues("cropId"),
+      userId: "user-1",
+    }));
 
-    console.log("Total batch tasks to create:", tasks.length);
     bulkCreateMutation.mutate(tasks);
   };
 
   const handleWorkCalculatorSave = (tasks: InsertTask[]) => {
-    console.log("Work calculator save called with tasks:", tasks);
     bulkCreateMutation.mutate(tasks);
   };
 
   const onSubmit = (data: InsertTask & { title: string; environment: string }) => {
-    console.log("Form submitted with data:", data);
-    console.log("Registration mode:", registrationMode);
-    console.log("Selected works:", selectedWorks);
-    console.log("Date range:", dateRange);
-    console.log("Form values:", {
-      title: form.getValues("title"),
-      taskType: form.getValues("taskType"),
-      scheduledDate: form.getValues("scheduledDate"),
-      farmId: form.getValues("farmId"),
-      cropId: form.getValues("cropId"),
-      description: form.getValues("description"),
-    });
-    
     const { environment, ...taskData } = data;
     
     if (task) {
       // 수정 모드
-      console.log("Updating existing task");
       updateMutation.mutate(taskData);
-    } else if (registrationMode === 'individual') {
-      // 개별 등록 - 날짜 범위
-      console.log("Creating individual tasks");
-      
-      // 개별 등록 모드 검증
-      if (!form.getValues("taskType")) {
-        toast({
-          title: "작업 유형을 선택해주세요",
-          variant: "destructive",
-        });
-        return;
-      }
-      
-      if (!dateRange.from || !dateRange.to) {
-        toast({
-          title: "날짜 범위를 선택해주세요",
-          variant: "destructive",
-        });
-        return;
-      }
-      
-      createIndividualTasks();
     } else if (registrationMode === 'batch') {
       // 일괄 등록 - 여러 작업
-      console.log("Creating batch tasks");
-      
-      // 일괄 등록 모드 검증
-      if (selectedWorks.length === 0) {
-        toast({
-          title: "작업을 선택해주세요",
-          variant: "destructive",
-        });
-        return;
-      }
-      
-      if (!form.getValues("scheduledDate")) {
-        toast({
-          title: "작업 날짜를 선택해주세요",
-          variant: "destructive",
-        });
-        return;
-      }
-      
       createBatchTasks();
     } else {
       // 단일 작업
-      console.log("Creating single task");
       createMutation.mutate(taskData);
     }
   };
@@ -418,9 +367,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
           </DialogHeader>
 
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit, (errors) => {
-              console.log("Form validation errors:", errors);
-            })} className="space-y-6">
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
               {/* 등록 방식 선택 (새 작업인 경우만) */}
               {!task && (
                 <div className="space-y-3">
@@ -477,10 +424,9 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
                       className="w-full justify-between"
                     >
                       핵심 작물 선택
-                      <ChevronDown className={cn(
-                        "h-4 w-4 transition-transform",
-                        showKeyCrops && "rotate-180"
-                      )} />
+                      <ChevronDown className={`h-4 w-4 transition-transform ${
+                        showKeyCrops ? "rotate-180" : ""
+                      }`} />
                     </Button>
                   </CollapsibleTrigger>
                   <CollapsibleContent className="mt-2">
@@ -492,9 +438,9 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
                           onClick={() => handleKeyCropSelect(keyCrop)}
                           className="text-left p-2 hover:bg-gray-50 rounded text-sm"
                         >
-                                                     <div className="font-medium">
-                             {keyCrop.category} {'>'} {keyCrop.name} {'>'} {keyCrop.variety}
-                           </div>
+                          <div className="font-medium">
+                            {keyCrop.category} {'>'} {keyCrop.name} {'>'} {keyCrop.variety}
+                          </div>
                           <div className="text-xs text-gray-500">
                             {keyCrop.description}
                           </div>
@@ -553,9 +499,11 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        <SelectItem value="노지">노지</SelectItem>
-                        <SelectItem value="시설1">시설1</SelectItem>
-                        <SelectItem value="시설2">시설2</SelectItem>
+                        {environments.map(env => (
+                          <SelectItem key={env} value={env}>
+                            {env}
+                          </SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
                     <FormMessage />
@@ -568,7 +516,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
                 <div className="space-y-3">
                   <Label>농작업 다중 선택 *</Label>
                   <div className="grid grid-cols-2 gap-2">
-                    {TASK_TYPES.map(type => (
+                    {taskTypes.map(type => (
                       <button
                         key={type}
                         type="button"
@@ -606,7 +554,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
-                          {TASK_TYPES.map(type => (
+                          {taskTypes.map(type => (
                             <SelectItem key={type} value={type}>
                               {type}
                             </SelectItem>
@@ -638,131 +586,48 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
               />
 
               {/* 날짜 선택 */}
-              {!task && registrationMode === 'individual' ? (
-                <div className="space-y-3">
-                  <Label>작업 기간 *</Label>
-                  <div className="grid grid-cols-2 gap-2">
-                    <div>
-                      <Label className="text-xs text-gray-500">시작일</Label>
-                      <Popover>
-                        <PopoverTrigger asChild>
+              <FormField
+                control={form.control}
+                name="scheduledDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>작업 날짜 *</FormLabel>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <FormControl>
                           <Button
                             variant="outline"
-                            className={cn(
-                              "w-full pl-3 text-left font-normal",
-                              !dateRange.from && "text-muted-foreground"
-                            )}
+                            className={`w-full pl-3 text-left font-normal ${
+                              !field.value ? "text-muted-foreground" : ""
+                            }`}
                           >
-                            {dateRange.from ? (
-                              format(new Date(dateRange.from), "MM/dd", { locale: ko })
+                            {field.value ? (
+                              format(new Date(field.value), "yyyy년 MM월 dd일", { locale: ko })
                             ) : (
-                              <span>시작일</span>
+                              <span>날짜를 선택해주세요</span>
                             )}
                             <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
                           </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calendar
-                            mode="single"
-                            selected={dateRange.from ? new Date(dateRange.from) : undefined}
-                            onSelect={(date) => {
-                              if (date) {
-                                const dateStr = format(date, "yyyy-MM-dd");
-                                setDateRange(prev => ({ ...prev, from: dateStr }));
-                                form.setValue("scheduledDate", dateStr);
-                              }
-                            }}
-                            disabled={(date) =>
-                              date < new Date(new Date().setHours(0, 0, 0, 0))
-                            }
-                            initialFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                    </div>
-                    <div>
-                      <Label className="text-xs text-gray-500">종료일</Label>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            variant="outline"
-                            className={cn(
-                              "w-full pl-3 text-left font-normal",
-                              !dateRange.to && "text-muted-foreground"
-                            )}
-                          >
-                            {dateRange.to ? (
-                              format(new Date(dateRange.to), "MM/dd", { locale: ko })
-                            ) : (
-                              <span>종료일</span>
-                            )}
-                            <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calendar
-                            mode="single"
-                            selected={dateRange.to ? new Date(dateRange.to) : undefined}
-                            onSelect={(date) => {
-                              if (date) {
-                                setDateRange(prev => ({ ...prev, to: format(date, "yyyy-MM-dd") }));
-                              }
-                            }}
-                            disabled={(date) =>
-                              date < new Date(dateRange.from || new Date().toISOString().split('T')[0])
-                            }
-                            initialFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <FormField
-                  control={form.control}
-                  name="scheduledDate"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>작업 날짜 *</FormLabel>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <FormControl>
-                            <Button
-                              variant="outline"
-                              className={cn(
-                                "w-full pl-3 text-left font-normal",
-                                !field.value && "text-muted-foreground"
-                              )}
-                            >
-                              {field.value ? (
-                                format(new Date(field.value), "yyyy년 MM월 dd일", { locale: ko })
-                              ) : (
-                                <span>날짜를 선택해주세요</span>
-                              )}
-                              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                            </Button>
-                          </FormControl>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calendar
-                            mode="single"
-                            selected={field.value ? new Date(field.value) : undefined}
-                            onSelect={(date) => {
-                              field.onChange(date ? format(date, "yyyy-MM-dd") : "");
-                            }}
-                            disabled={(date) =>
-                              date < new Date(new Date().setHours(0, 0, 0, 0))
-                            }
-                            initialFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              )}
+                        </FormControl>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                          mode="single"
+                          selected={field.value ? new Date(field.value) : undefined}
+                          onSelect={(date) => {
+                            field.onChange(date ? format(date, "yyyy-MM-dd") : "");
+                          }}
+                          disabled={(date) =>
+                            date < new Date(new Date().setHours(0, 0, 0, 0))
+                          }
+                          initialFocus
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
               <FormField
                 control={form.control}
@@ -815,7 +680,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
                       "저장 중..." : 
                       task ? "수정 완료" :
                       registrationMode === 'batch' ? `${selectedWorks.length}개 작업 등록` :
-                      registrationMode === 'individual' ? "날짜 범위 등록" : "저장하기"
+                      "저장하기"
                     }
                   </Button>
                 )}

--- a/FarmMate/client/src/components/add-task-dialog-improved.tsx
+++ b/FarmMate/client/src/components/add-task-dialog-improved.tsx
@@ -180,11 +180,22 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
   // 제목 자동 설정
   useEffect(() => {
     const taskType = form.getValues("taskType");
-    if (cropSearchTerm && taskType) {
-      const autoTitle = `${cropSearchTerm}_${taskType}`;
+    const cropName = customCropName || cropSearchTerm;
+    if (cropName && taskType) {
+      const autoTitle = `${cropName}_${taskType}`;
       form.setValue("title", autoTitle);
     }
-  }, [cropSearchTerm, form]);
+  }, [cropSearchTerm, customCropName, form]);
+
+  // taskType 변경 시 제목 업데이트
+  useEffect(() => {
+    const taskType = form.watch("taskType");
+    const cropName = customCropName || cropSearchTerm;
+    if (cropName && taskType) {
+      const autoTitle = `${cropName}_${taskType}`;
+      form.setValue("title", autoTitle);
+    }
+  }, [form.watch("taskType"), customCropName, cropSearchTerm, form]);
 
   // 태스크 수정 모드인 경우 초기값 설정
   useEffect(() => {
@@ -321,8 +332,9 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
   };
 
   const handleKeyCropSelect = (keyCrop: typeof KEY_CROPS[0]) => {
-    setCropSearchTerm(`${keyCrop.category} > ${keyCrop.name} > ${keyCrop.variety}`);
-    setCustomCropName(`${keyCrop.category} > ${keyCrop.name} > ${keyCrop.variety}`);
+    const displayName = `${keyCrop.name} > ${keyCrop.variety}`;
+    setCropSearchTerm(displayName);
+    setCustomCropName(displayName);
     form.setValue("cropId", ""); // 커스텀 작물로 처리
     setShowKeyCrops(false);
   };

--- a/FarmMate/client/src/components/add-task-dialog-improved.tsx
+++ b/FarmMate/client/src/components/add-task-dialog-improved.tsx
@@ -124,7 +124,7 @@ const KEY_CROPS = [
   }
 ];
 
-// 일괄등록용 작업 목록 (파종, 육묘, 수확-선별만)
+// 일괄등록용 작업 목록 (파종, 육묘, 수확만)
 const batchTaskTypes = [
   "파종", "육묘", "수확"
 ];
@@ -132,7 +132,7 @@ const batchTaskTypes = [
 // 개별등록용 작업 목록 (기존 7개)
 const individualTaskTypes = [
   "파종", "육묘", "이랑준비", "정식", "풀/병해충/수분 관리", 
-  "고르기", "수확-선별", "저장-포장"
+  "고르기", "수확", "저장-포장"
 ];
 
 const environments = ["노지", "시설1", "시설2"];
@@ -236,6 +236,14 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
       });
       onOpenChange(false);
     },
+    onError: (error) => {
+      console.error("Task creation error:", error);
+      toast({
+        title: "작업 등록 실패",
+        description: "작업 등록 중 오류가 발생했습니다. 다시 시도해주세요.",
+        variant: "destructive",
+      });
+    },
   });
 
   const updateMutation = useMutation({
@@ -248,6 +256,14 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
         description: "변경된 일정이 저장되었습니다.",
       });
       onOpenChange(false);
+    },
+    onError: (error) => {
+      console.error("Task update error:", error);
+      toast({
+        title: "작업 수정 실패",
+        description: "작업 수정 중 오류가 발생했습니다. 다시 시도해주세요.",
+        variant: "destructive",
+      });
     },
   });
 
@@ -263,6 +279,14 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
         description: "작업 일정이 추가되었습니다.",
       });
       onOpenChange(false);
+    },
+    onError: (error) => {
+      console.error("Bulk task creation error:", error);
+      toast({
+        title: "작업 등록 실패",
+        description: "일괄 작업 등록 중 오류가 발생했습니다. 다시 시도해주세요.",
+        variant: "destructive",
+      });
     },
   });
 
@@ -381,7 +405,8 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
       createBatchTasks();
     } else {
       // 단일 작업
-      createMutation.mutate(taskData as InsertTask);
+      const taskWithUserId = { ...taskData, userId: "user-1" } as InsertTask;
+      createMutation.mutate(taskWithUserId);
     }
   };
 
@@ -745,7 +770,9 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
                 >
                   취소
                 </Button>
-                {registrationMode === 'batch' && !task ? (
+                
+                {/* 일괄등록 모드에서 농작업 계산기 버튼 */}
+                {registrationMode === 'batch' && !task && (
                   <Button 
                     type="button"
                     onClick={openWorkCalculator}
@@ -755,25 +782,25 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
                     <Calculator className="w-4 h-4 mr-2" />
                     농작업 계산기
                   </Button>
-                ) : (
-                  <Button 
-                    type="submit" 
-                    className="flex-1"
-                    disabled={
-                      createMutation.isPending || 
-                      updateMutation.isPending || 
-                      bulkCreateMutation.isPending ||
-                      (!task && registrationMode === 'batch' && selectedWorks.length === 0)
-                    }
-                  >
-                    {createMutation.isPending || updateMutation.isPending || bulkCreateMutation.isPending ? 
-                      "저장 중..." : 
-                      task ? "수정 완료" :
-                      registrationMode === 'batch' ? `${selectedWorks.length}개 작업 등록` :
-                      "저장하기"
-                    }
-                  </Button>
                 )}
+                
+                {/* 저장하기 버튼 */}
+                <Button 
+                  type="submit" 
+                  className="flex-1"
+                  disabled={
+                    createMutation.isPending || 
+                    updateMutation.isPending || 
+                    bulkCreateMutation.isPending ||
+                    (!task && registrationMode === 'batch' && selectedWorks.length === 0)
+                  }
+                >
+                  {createMutation.isPending || updateMutation.isPending || bulkCreateMutation.isPending ? 
+                    "저장 중..." : 
+                    task ? "수정 완료" :
+                    "저장하기"
+                  }
+                </Button>
               </div>
             </form>
           </Form>

--- a/FarmMate/client/src/components/add-task-dialog.tsx
+++ b/FarmMate/client/src/components/add-task-dialog.tsx
@@ -97,11 +97,11 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
       
       form.reset({
         title: task.title,
-        description: task.description,
+        description: task.description || undefined,
         taskType: task.taskType,
         scheduledDate: task.scheduledDate,
-        farmId: task.farmId,
-        cropId: task.cropId,
+        farmId: task.farmId || undefined,
+        cropId: task.cropId || undefined,
         environment: farm?.environment || "",
         farmNumber: farm?.name || "",
       });
@@ -164,7 +164,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
     const crop = crops?.find(c => c.id === cropId);
     if (crop) {
       form.setValue("cropId", cropId);
-      form.setValue("farmId", crop.farmId);
+      form.setValue("farmId", crop.farmId || "");
       setCropSearchTerm(crop.name);
       
       // 농장의 재배환경 설정
@@ -190,7 +190,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-full max-w-md mx-auto">
+              <DialogContent className="w-full max-w-md mx-auto max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{task ? "일정 수정하기" : "새 작업 추가하기"}</DialogTitle>
         </DialogHeader>
@@ -380,7 +380,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
               )}
             />
 
-            <div className="flex space-x-2">
+            <div className="flex space-x-2 sticky bottom-0 bg-white pt-4 border-t">
               <Button 
                 type="button" 
                 variant="outline" 

--- a/FarmMate/client/src/components/add-task-dialog.tsx
+++ b/FarmMate/client/src/components/add-task-dialog.tsx
@@ -1,21 +1,20 @@
 import { useState, useEffect } from "react";
 import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
-import { Calendar, CalendarIcon, Check, Search, Calculator } from "lucide-react";
+import { CalendarIcon, Check, Search } from "lucide-react";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@shared/ui/button";
+import { Input } from "@shared/ui/input";
+import { Label } from "@shared/ui/label";
+import { Textarea } from "@shared/ui/textarea";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
+} from "@shared/ui/dialog";
 import {
   Form,
   FormControl,
@@ -23,35 +22,38 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@/components/ui/form";
+} from "@shared/ui/form";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
+} from "@shared/ui/select";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/ui/popover";
-import { useToast } from "@/hooks/use-toast";
-import { insertTaskSchema } from "@shared/schema";
-import type { InsertTask, Task, Farm, Crop } from "@shared/schema";
-import { apiRequest } from "@/lib/queryClient";
-import WorkCalculatorDialog from "./work-calculator-dialog";
+} from "@shared/ui/popover";
+import { useToast } from "@shared/hooks/use-toast";
+import { insertTaskSchema } from "../../../shared/schema";
+import type { InsertTask, Task, Farm, Crop } from "../../../shared/schema";
+import { apiRequest } from "@shared/api/client";
 import { z } from "zod";
+import { Calendar } from "@shared/ui/calendar";
 
 const formSchema = insertTaskSchema.extend({
   title: z.string().min(1, "제목을 입력해주세요"),
   environment: z.string().min(1, "재배환경을 선택해주세요"),
+  farmNumber: z.string().min(1, "농장 번호를 입력해주세요"),
 });
 
 const taskTypes = [
   "파종", "육묘", "정식", "물주기", "비료주기", 
   "약치기", "풀매기", "가지치기", "수확"
 ];
+
+const environments = ["노지", "시설1", "시설2"];
 
 interface AddTaskDialogProps {
   open: boolean;
@@ -63,12 +65,7 @@ interface AddTaskDialogProps {
 export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }: AddTaskDialogProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const [registrationMode, setRegistrationMode] = useState<'batch' | 'individual'>('batch');
-  const [selectedWorks, setSelectedWorks] = useState<string[]>([]);
   const [cropSearchTerm, setCropSearchTerm] = useState("");
-  const [customCropName, setCustomCropName] = useState("");
-  const [dateRange, setDateRange] = useState({ from: "", to: "" });
-  const [showWorkCalculator, setShowWorkCalculator] = useState(false);
 
   const { data: farms } = useQuery<Farm[]>({
     queryKey: ["/api/farms"],
@@ -78,7 +75,7 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
     queryKey: ["/api/crops"],
   });
 
-  const form = useForm<InsertTask & { title: string; environment: string }>({
+  const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
       title: "",
@@ -87,8 +84,8 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
       scheduledDate: selectedDate || "",
       farmId: "",
       cropId: "",
-      userId: "user-1",
       environment: "",
+      farmNumber: "",
     },
   });
 
@@ -105,13 +102,8 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
         scheduledDate: task.scheduledDate,
         farmId: task.farmId,
         cropId: task.cropId,
-        userId: task.userId,
         environment: farm?.environment || "",
-      });
-      
-      setDateRange({
-        from: task.scheduledDate,
-        to: task.scheduledDate
+        farmNumber: farm?.name || "",
       });
       
       if (crop) {
@@ -126,24 +118,19 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
         scheduledDate: selectedDate || "",
         farmId: "",
         cropId: "",
-        userId: "user-1",
         environment: "",
+        farmNumber: "",
       });
       
       const today = selectedDate || format(new Date(), "yyyy-MM-dd");
-      setDateRange({ from: today, to: today });
+      form.setValue("scheduledDate", today);
       setCropSearchTerm("");
-      setCustomCropName("");
-      setSelectedWorks([]);
     }
   }, [task, open, selectedDate, crops, farms, form]);
 
   const createMutation = useMutation({
-    mutationFn: (data: InsertTask) => 
-      apiRequest("/api/tasks", {
-        method: "POST",
-        body: JSON.stringify(data),
-      }),
+    mutationFn: (data: any) => 
+      apiRequest("POST", "/api/tasks", data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/tasks"] });
       toast({
@@ -155,11 +142,8 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
   });
 
   const updateMutation = useMutation({
-    mutationFn: (data: InsertTask) => 
-      apiRequest(`/api/tasks/${task?.id}`, {
-        method: "PUT",
-        body: JSON.stringify(data),
-      }),
+    mutationFn: (data: any) => 
+      apiRequest("PUT", `/api/tasks/${task?.id}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/tasks"] });
       toast({
@@ -170,37 +154,11 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
     },
   });
 
-  const bulkCreateMutation = useMutation({
-    mutationFn: (tasks: InsertTask[]) => 
-      Promise.all(tasks.map(task => 
-        apiRequest("/api/tasks", {
-          method: "POST",
-          body: JSON.stringify(task),
-        })
-      )),
-    onSuccess: (_, tasks) => {
-      queryClient.invalidateQueries({ queryKey: ["/api/tasks"] });
-      toast({
-        title: "일정이 등록되었습니다.",
-        description: `${tasks.length}개의 작업 일정이 추가되었습니다.`,
-      });
-      onOpenChange(false);
-    },
-  });
-
   // 작물 검색 필터링
   const searchFilteredCrops = crops?.filter(crop =>
     crop.name.toLowerCase().includes(cropSearchTerm.toLowerCase()) ||
     crop.category.toLowerCase().includes(cropSearchTerm.toLowerCase())
   ) || [];
-
-  const handleWorkToggle = (work: string) => {
-    setSelectedWorks(prev =>
-      prev.includes(work)
-        ? prev.filter(w => w !== work)
-        : [...prev, work]
-    );
-  };
 
   const handleCropSelect = (cropId: string) => {
     const crop = crops?.find(c => c.id === cropId);
@@ -213,449 +171,238 @@ export default function AddTaskDialog({ open, onOpenChange, selectedDate, task }
       const farm = farms?.find(f => f.id === crop.farmId);
       if (farm) {
         form.setValue("environment", farm.environment);
+        form.setValue("farmNumber", farm.name);
       }
     }
   };
 
-  const handleCustomCropInput = (cropName: string) => {
-    setCustomCropName(cropName);
-    setCropSearchTerm(cropName);
-    form.setValue("cropId", ""); // 커스텀 작물인 경우 cropId는 빈 값
-  };
-
-  // 개별 등록 - 날짜 범위 내 모든 날짜에 작업 생성
-  const createIndividualTasks = () => {
-    if (!dateRange.from || !dateRange.to) {
-      toast({
-        title: "날짜 범위를 선택해주세요",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    const startDate = new Date(dateRange.from);
-    const endDate = new Date(dateRange.to);
-    const tasks: InsertTask[] = [];
-    
-    const taskType = form.getValues("taskType");
-    const cropName = customCropName || crops?.find(c => c.id === form.getValues("cropId"))?.name || "작물";
-    
-    // 날짜 범위 내 모든 날짜에 대해 작업 생성
-    for (let date = new Date(startDate); date <= endDate; date.setDate(date.getDate() + 1)) {
-      const dateStr = format(date, "yyyy-MM-dd");
-      tasks.push({
-        title: `${cropName} ${taskType}`,
-        description: form.getValues("description") || `개별 등록으로 생성된 ${taskType} 작업`,
-        taskType: taskType,
-        scheduledDate: dateStr,
-        farmId: form.getValues("farmId"),
-        cropId: form.getValues("cropId"),
-        userId: "user-1",
-      });
-    }
-
-    bulkCreateMutation.mutate(tasks);
-  };
-
-  // 일괄 등록 - 여러 작업을 한 날짜에 등록
-  const createBatchTasks = () => {
-    if (selectedWorks.length === 0) {
-      toast({
-        title: "작업을 선택해주세요",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    const cropName = customCropName || crops?.find(c => c.id === form.getValues("cropId"))?.name || "작물";
-    const tasks = selectedWorks.map(work => ({
-      title: `${cropName} ${work}`,
-      description: form.getValues("description") || `일괄 등록으로 생성된 ${work} 작업`,
-      taskType: work,
-      scheduledDate: form.getValues("scheduledDate"),
-      farmId: form.getValues("farmId"),
-      cropId: form.getValues("cropId"),
-      userId: "user-1",
-    }));
-
-    bulkCreateMutation.mutate(tasks);
-  };
-
-  const onSubmit = (data: InsertTask & { title: string; environment: string }) => {
-    const { environment, ...taskData } = data;
+  const onSubmit = (data: any) => {
+    const { environment, farmNumber, ...taskData } = data;
     
     if (task) {
       // 수정 모드
       updateMutation.mutate(taskData);
-    } else if (registrationMode === 'individual') {
-      // 개별 등록 - 날짜 범위
-      createIndividualTasks();
-    } else if (registrationMode === 'batch') {
-      // 일괄 등록 - 여러 작업
-      createBatchTasks();
     } else {
-      // 단일 작업
+      // 새 작업 생성
       createMutation.mutate(taskData);
     }
   };
 
   return (
-    <>
-      <Dialog open={open && !showWorkCalculator} onOpenChange={onOpenChange}>
-        <DialogContent className="w-full max-w-md mx-auto">
-          <DialogHeader>
-            <DialogTitle>{task ? "일정 수정하기" : "일정 추가하기"}</DialogTitle>
-          </DialogHeader>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-full max-w-md mx-auto">
+        <DialogHeader>
+          <DialogTitle>{task ? "일정 수정하기" : "새 작업 추가하기"}</DialogTitle>
+        </DialogHeader>
 
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-              {/* 등록 방식 선택 (새 작업인 경우만) */}
-              {!task && (
-                <div className="space-y-3">
-                  <Label>등록 방식</Label>
-                  <div className="flex bg-gray-100 rounded-lg p-1">
-                    <button
-                      type="button"
-                      onClick={() => setRegistrationMode('batch')}
-                      className={`flex-1 px-3 py-2 rounded text-sm font-medium transition-colors ${
-                        registrationMode === 'batch'
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-500 hover:text-gray-700'
-                      }`}
-                    >
-                      일괄등록
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setRegistrationMode('individual')}
-                      className={`flex-1 px-3 py-2 rounded text-sm font-medium transition-colors ${
-                        registrationMode === 'individual'
-                          ? 'bg-white text-gray-900 shadow-sm'
-                          : 'text-gray-500 hover:text-gray-700'
-                      }`}
-                    >
-                      일괄등록
-                    </button>
-                  </div>
-                  <p className="text-xs text-gray-500">
-                    {registrationMode === 'batch' 
-                      ? "여러 농작업을 한 날짜에 등록합니다" 
-                      : "하나의 농작업을 날짜 범위에 등록합니다"
-                    }
-                  </p>
-                </div>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            {/* 제목 입력 */}
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>제목 *</FormLabel>
+                  <FormControl>
+                    <Input placeholder="작업 제목을 입력해주세요" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
+            />
 
-              {/* 작물 검색 및 선택 */}
-              <div className="space-y-3">
-                <Label>작물 *</Label>
-                <div className="relative">
-                  <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    placeholder="작물명을 입력하세요"
-                    value={cropSearchTerm}
-                    onChange={(e) => {
-                      setCropSearchTerm(e.target.value);
-                      handleCustomCropInput(e.target.value);
-                    }}
-                    className="pl-10"
-                  />
-                </div>
-                
-                {cropSearchTerm && searchFilteredCrops.length > 0 && (
-                  <div className="max-h-32 overflow-y-auto border rounded-md">
-                    {searchFilteredCrops.map(crop => {
-                      const farm = farms?.find(f => f.id === crop.farmId);
-                      return (
-                        <button
-                          key={crop.id}
-                          type="button"
-                          onClick={() => handleCropSelect(crop.id)}
-                          className={`w-full text-left p-2 hover:bg-gray-50 border-b last:border-b-0 ${
-                            form.getValues("cropId") === crop.id ? "bg-blue-50 border-blue-200" : ""
-                          }`}
-                        >
-                          <div className="flex items-center justify-between">
-                            <div>
-                              <span className="font-medium">{crop.name}</span>
-                              <span className="text-sm text-gray-500 ml-2">({crop.variety})</span>
-                            </div>
-                            <div className="text-xs text-gray-400">
-                              {farm?.name} · {farm?.environment}
-                            </div>
-                          </div>
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
+            {/* 재배환경 선택 */}
+            <FormField
+              control={form.control}
+              name="environment"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>재배환경 *</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="재배환경을 선택해주세요" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {environments.map(env => (
+                        <SelectItem key={env} value={env}>{env}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* 농장 번호 */}
+            <FormField
+              control={form.control}
+              name="farmNumber"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>농장 번호 *</FormLabel>
+                  <FormControl>
+                    <Input placeholder="농장 번호를 입력해주세요" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* 작물 검색 및 선택 */}
+            <div className="space-y-3">
+              <Label>작물 선택 *</Label>
+              <div className="relative">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                <Input
+                  placeholder="작물명을 입력하세요"
+                  value={cropSearchTerm}
+                  onChange={(e) => setCropSearchTerm(e.target.value)}
+                  className="pl-10"
+                />
               </div>
-
-              {/* 재배환경 */}
-              <FormField
-                control={form.control}
-                name="environment"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>재배환경 *</FormLabel>
-                    <Select onValueChange={field.onChange} value={field.value}>
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="재배환경을 선택해주세요" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="노지">노지</SelectItem>
-                        <SelectItem value="시설1">시설1</SelectItem>
-                        <SelectItem value="시설2">시설2</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* 농작업 선택 */}
-              {!task && registrationMode === 'batch' ? (
-                <div className="space-y-3">
-                  <Label>농작업 다중 선택 *</Label>
-                  <div className="grid grid-cols-2 gap-2">
-                    {taskTypes.map(type => (
+              
+              {cropSearchTerm && searchFilteredCrops.length > 0 && (
+                <div className="max-h-32 overflow-y-auto border rounded-md">
+                  {searchFilteredCrops.map(crop => {
+                    const farm = farms?.find(f => f.id === crop.farmId);
+                    return (
                       <button
-                        key={type}
+                        key={crop.id}
                         type="button"
-                        onClick={() => handleWorkToggle(type)}
-                        className={`p-2 text-sm border rounded transition-colors ${
-                          selectedWorks.includes(type)
-                            ? 'border-blue-500 bg-blue-50 text-blue-700'
-                            : 'border-gray-200 hover:border-gray-300'
+                        onClick={() => handleCropSelect(crop.id)}
+                        className={`w-full text-left p-2 hover:bg-gray-50 border-b last:border-b-0 ${
+                          form.getValues("cropId") === crop.id ? "bg-blue-50 border-blue-200" : ""
                         }`}
                       >
-                        {selectedWorks.includes(type) && (
-                          <Check className="h-3 w-3 inline mr-1" />
-                        )}
-                        {type}
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <span className="font-medium">{crop.name}</span>
+                            <span className="text-sm text-gray-500 ml-2">({crop.variety})</span>
+                          </div>
+                          <div className="text-xs text-gray-400">
+                            {farm?.name} · {farm?.environment}
+                          </div>
+                        </div>
                       </button>
-                    ))}
-                  </div>
-                  {selectedWorks.length > 0 && (
-                    <p className="text-xs text-gray-600">
-                      {selectedWorks.length}개 작업 선택됨
-                    </p>
-                  )}
+                    );
+                  })}
                 </div>
-              ) : (
-                <FormField
-                  control={form.control}
-                  name="taskType"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>농작업 *</FormLabel>
-                      <Select onValueChange={field.onChange} value={field.value}>
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="작업 유형을 선택해주세요" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {taskTypes.map(type => (
-                            <SelectItem key={type} value={type}>
-                              {type}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
               )}
+            </div>
 
-              {/* 날짜 선택 */}
-              {!task && registrationMode === 'individual' ? (
-                <div className="space-y-3">
-                  <Label>작업 기간 *</Label>
-                  <div className="grid grid-cols-2 gap-2">
-                    <div>
-                      <Label className="text-xs text-gray-500">시작일</Label>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            variant="outline"
-                            className={cn(
-                              "w-full pl-3 text-left font-normal",
-                              !dateRange.from && "text-muted-foreground"
-                            )}
-                          >
-                            {dateRange.from ? (
-                              format(new Date(dateRange.from), "MM/dd", { locale: ko })
-                            ) : (
-                              <span>시작일</span>
-                            )}
-                            <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calendar
-                            mode="single"
-                            selected={dateRange.from ? new Date(dateRange.from) : undefined}
-                            onSelect={(date) => {
-                              if (date) {
-                                const dateStr = format(date, "yyyy-MM-dd");
-                                setDateRange(prev => ({ ...prev, from: dateStr }));
-                                form.setValue("scheduledDate", dateStr);
-                              }
-                            }}
-                            disabled={(date) =>
-                              date < new Date(new Date().setHours(0, 0, 0, 0))
-                            }
-                            initialFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                    </div>
-                    <div>
-                      <Label className="text-xs text-gray-500">종료일</Label>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            variant="outline"
-                            className={cn(
-                              "w-full pl-3 text-left font-normal",
-                              !dateRange.to && "text-muted-foreground"
-                            )}
-                          >
-                            {dateRange.to ? (
-                              format(new Date(dateRange.to), "MM/dd", { locale: ko })
-                            ) : (
-                              <span>종료일</span>
-                            )}
-                            <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calendar
-                            mode="single"
-                            selected={dateRange.to ? new Date(dateRange.to) : undefined}
-                            onSelect={(date) => {
-                              if (date) {
-                                setDateRange(prev => ({ ...prev, to: format(date, "yyyy-MM-dd") }));
-                              }
-                            }}
-                            disabled={(date) =>
-                              date < new Date(dateRange.from || new Date().toISOString().split('T')[0])
-                            }
-                            initialFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <FormField
-                  control={form.control}
-                  name="scheduledDate"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>작업 날짜 *</FormLabel>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <FormControl>
-                            <Button
-                              variant="outline"
-                              className={cn(
-                                "w-full pl-3 text-left font-normal",
-                                !field.value && "text-muted-foreground"
-                              )}
-                            >
-                              {field.value ? (
-                                format(new Date(field.value), "yyyy년 MM월 dd일", { locale: ko })
-                              ) : (
-                                <span>날짜를 선택해주세요</span>
-                              )}
-                              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                            </Button>
-                          </FormControl>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calendar
-                            mode="single"
-                            selected={field.value ? new Date(field.value) : undefined}
-                            onSelect={(date) => {
-                              field.onChange(date ? format(date, "yyyy-MM-dd") : "");
-                            }}
-                            disabled={(date) =>
-                              date < new Date(new Date().setHours(0, 0, 0, 0))
-                            }
-                            initialFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              )}
-
-              <FormField
-                control={form.control}
-                name="description"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>메모 (선택사항)</FormLabel>
+            {/* 농작업 선택 */}
+            <FormField
+              control={form.control}
+              name="taskType"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>농작업 선택 *</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
                     <FormControl>
-                      <Textarea
-                        placeholder="추가 메모를 입력하세요"
-                        {...field}
-                      />
+                      <SelectTrigger>
+                        <SelectValue placeholder="작업 유형을 선택해주세요" />
+                      </SelectTrigger>
                     </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                    <SelectContent>
+                      {taskTypes.map(type => (
+                        <SelectItem key={type} value={type}>
+                          {type}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-              <div className="flex space-x-2">
-                <Button 
-                  type="button" 
-                  variant="outline" 
-                  onClick={() => onOpenChange(false)}
-                  className="flex-1"
-                >
-                  취소
-                </Button>
-                <Button 
-                  type="submit" 
-                  className="flex-1"
-                  disabled={
-                    createMutation.isPending || 
-                    updateMutation.isPending || 
-                    bulkCreateMutation.isPending ||
-                    (!task && registrationMode === 'batch' && selectedWorks.length === 0)
-                  }
-                >
-                  {createMutation.isPending || updateMutation.isPending || bulkCreateMutation.isPending ? 
-                    "저장 중..." : 
-                    task ? "수정 완료" :
-                    registrationMode === 'batch' ? `${selectedWorks.length}개 작업 등록` :
-                    registrationMode === 'individual' ? "날짜 범위 등록" : "저장하기"
-                  }
-                </Button>
-              </div>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
+            {/* 날짜 선택 */}
+            <FormField
+              control={form.control}
+              name="scheduledDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>작업 날짜 *</FormLabel>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <FormControl>
+                        <Button
+                          variant="outline"
+                          className="w-full pl-3 text-left font-normal"
+                        >
+                          {field.value ? (
+                            format(new Date(field.value), "yyyy년 MM월 dd일", { locale: ko })
+                          ) : (
+                            <span>날짜를 선택해주세요</span>
+                          )}
+                          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        </Button>
+                      </FormControl>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={field.value ? new Date(field.value) : undefined}
+                        onSelect={(date) => {
+                          if (date) {
+                            field.onChange(format(date, "yyyy-MM-dd"));
+                          }
+                        }}
+                        disabled={(date) =>
+                          date < new Date(new Date().setHours(0, 0, 0, 0))
+                        }
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-      {/* Work Calculator Dialog */}
-      <WorkCalculatorDialog 
-        open={showWorkCalculator}
-        onOpenChange={setShowWorkCalculator}
-        selectedCrops={[]}
-        selectedWork={form.getValues("taskType")}
-        baseDate={form.getValues("scheduledDate")}
-        crops={crops || []}
-      />
-    </>
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>메모 (선택사항)</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="추가 메모를 입력하세요"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex space-x-2">
+              <Button 
+                type="button" 
+                variant="outline" 
+                onClick={() => onOpenChange(false)}
+                className="flex-1"
+              >
+                취소
+              </Button>
+              <Button 
+                type="submit" 
+                className="flex-1"
+                disabled={createMutation.isPending || updateMutation.isPending}
+              >
+                {createMutation.isPending || updateMutation.isPending ? 
+                  "저장 중..." : 
+                  task ? "수정 완료" : "저장하기"
+                }
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/FarmMate/client/src/components/calendar-grid.tsx
+++ b/FarmMate/client/src/components/calendar-grid.tsx
@@ -1,4 +1,4 @@
-import type { Task, Crop } from "@shared/schema";
+import type { Task, Crop } from "../../../shared/schema";
 
 interface CalendarGridProps {
   currentDate: Date;

--- a/FarmMate/client/src/components/edit-task-dialog.tsx
+++ b/FarmMate/client/src/components/edit-task-dialog.tsx
@@ -315,7 +315,7 @@ export function EditTaskDialog({ task, trigger }: EditTaskDialogProps) {
             />
           </div>
 
-          <div className="flex justify-end space-x-2">
+          <div className="flex justify-end space-x-2 sticky bottom-0 bg-white pt-4 border-t">
             <Button variant="outline" onClick={() => setOpen(false)}>
               취소
             </Button>

--- a/FarmMate/client/src/components/new-add-task-dialog.tsx
+++ b/FarmMate/client/src/components/new-add-task-dialog.tsx
@@ -571,13 +571,15 @@ export default function NewAddTaskDialog({ open, onOpenChange, selectedDate }: N
           </div>
 
           {/* 저장 버튼 */}
-          <Button
-            onClick={() => onSubmit({} as any)}
-            className="w-full bg-black text-white hover:bg-gray-800"
-            disabled={createTaskMutation.isPending}
-          >
-            {createTaskMutation.isPending ? "저장 중..." : "저장하기"}
-          </Button>
+          <div className="sticky bottom-0 bg-white pt-4 border-t">
+            <Button
+              onClick={() => onSubmit({} as any)}
+              className="w-full bg-black text-white hover:bg-gray-800"
+              disabled={createTaskMutation.isPending}
+            >
+              {createTaskMutation.isPending ? "저장 중..." : "저장하기"}
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/FarmMate/client/src/components/new-add-task-dialog.tsx
+++ b/FarmMate/client/src/components/new-add-task-dialog.tsx
@@ -48,7 +48,7 @@ const formSchema = insertTaskSchema.extend({
 });
 
 const taskTypes = [
-  "파종", "육묘", "수확", "기타(직접 입력)"
+  "파종", "육묘", "수확"
 ];
 
 interface NewAddTaskDialogProps {

--- a/FarmMate/client/src/components/new-add-task-dialog.tsx
+++ b/FarmMate/client/src/components/new-add-task-dialog.tsx
@@ -38,8 +38,8 @@ import {
 } from "@/components/ui/popover";
 import { Calendar as CalendarComponent } from "@/components/ui/calendar";
 import { useToast } from "@/hooks/use-toast";
-import { insertTaskSchema } from "@shared/schema";
-import type { InsertTask, Task, Farm, Crop } from "@shared/schema";
+import { insertTaskSchema } from "../shared/types/schema";
+import type { InsertTask, Task, Farm, Crop } from "../shared/types/schema";
 import { apiRequest } from "@/lib/queryClient";
 import { z } from "zod";
 
@@ -48,8 +48,7 @@ const formSchema = insertTaskSchema.extend({
 });
 
 const taskTypes = [
-  "파종", "육묘", "이량준비 및 정식", "정식", "풀/병해충/수분 관리", 
-  "고르기", "수확·선별", "저장·포장", "기타 (직접 입력)"
+  "파종", "육묘", "수확", "기타(직접 입력)"
 ];
 
 interface NewAddTaskDialogProps {
@@ -105,7 +104,6 @@ export default function NewAddTaskDialog({ open, onOpenChange, selectedDate }: N
       description: "",
       farmId: "",
       cropId: "",
-      userId: "user-1",
       environment: "",
     },
   });
@@ -289,7 +287,6 @@ export default function NewAddTaskDialog({ open, onOpenChange, selectedDate }: N
         selectedRows.forEach(row => {
           const defaultTitle = `${selectedCrop || '작물'} ${work}`;
           tasksToCreate.push({
-            userId: "user-1",
             title: customTitle || defaultTitle,
             taskType: work,
             cropId: targetCrop?.id || "",
@@ -311,7 +308,6 @@ export default function NewAddTaskDialog({ open, onOpenChange, selectedDate }: N
           selectedRows.forEach(row => {
             const defaultTitle = `${selectedCrop || '작물'} ${work}`;
             tasksToCreate.push({
-              userId: "user-1",
               title: customTitle || defaultTitle,
               taskType: work,
               cropId: targetCrop?.id || "",

--- a/FarmMate/client/src/components/simple-edit-task-dialog.tsx
+++ b/FarmMate/client/src/components/simple-edit-task-dialog.tsx
@@ -147,7 +147,7 @@ export default function SimpleEditTaskDialog({ open, onOpenChange, task }: Simpl
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+              <DialogContent className="sm:max-w-[425px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>일정 수정</DialogTitle>
         </DialogHeader>
@@ -279,7 +279,7 @@ export default function SimpleEditTaskDialog({ open, onOpenChange, task }: Simpl
             />
           </div>
 
-          <div className="flex space-x-2">
+          <div className="flex space-x-2 sticky bottom-0 bg-white pt-4 border-t">
             <Button 
               type="submit" 
               className="flex-1"

--- a/FarmMate/client/src/components/work-calculator-dialog.tsx
+++ b/FarmMate/client/src/components/work-calculator-dialog.tsx
@@ -23,7 +23,7 @@ import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { BATCH_TASK_SCHEDULES, TASK_TYPES } from "@/shared/constants/crops";
-import type { Crop, InsertTask } from "@shared/schema";
+import type { Crop, InsertTask } from "../shared/types/schema";
 
 interface WorkCalculatorDialogProps {
   open: boolean;
@@ -31,6 +31,7 @@ interface WorkCalculatorDialogProps {
   selectedCrop: Crop | null;
   baseDate: string;
   onSave: (tasks: InsertTask[]) => void;
+  selectedTasks?: string[];
 }
 
 interface TaskSchedule {
@@ -46,15 +47,23 @@ export default function WorkCalculatorDialog({
   onOpenChange, 
   selectedCrop,
   baseDate,
-  onSave
+  onSave,
+  selectedTasks: propSelectedTasks
 }: WorkCalculatorDialogProps) {
   const { toast } = useToast();
   
   const [totalDuration, setTotalDuration] = useState(70);
   const [taskSchedules, setTaskSchedules] = useState<TaskSchedule[]>([]);
-  const [selectedTasks, setSelectedTasks] = useState<string[]>([
-    "이랑준비", "파종", "고르기", "수확-선별", "저장-포장"
-  ]);
+  const [selectedTasks, setSelectedTasks] = useState<string[]>(
+    propSelectedTasks || ["파종", "육묘", "수확-선별"]
+  );
+
+  // propSelectedTasks가 변경되면 selectedTasks 업데이트
+  useEffect(() => {
+    if (propSelectedTasks && propSelectedTasks.length > 0) {
+      setSelectedTasks(propSelectedTasks);
+    }
+  }, [propSelectedTasks]);
 
   // 선택된 작업에 따라 일정 계산
   useEffect(() => {

--- a/FarmMate/client/src/components/work-calculator-dialog.tsx
+++ b/FarmMate/client/src/components/work-calculator-dialog.tsx
@@ -55,7 +55,7 @@ export default function WorkCalculatorDialog({
   const [totalDuration, setTotalDuration] = useState(70);
   const [taskSchedules, setTaskSchedules] = useState<TaskSchedule[]>([]);
   const [selectedTasks, setSelectedTasks] = useState<string[]>(
-    propSelectedTasks || ["파종", "육묘", "수확-선별"]
+    propSelectedTasks || ["파종", "육묘", "수확"]
   );
 
   // propSelectedTasks가 변경되면 selectedTasks 업데이트
@@ -141,8 +141,8 @@ export default function WorkCalculatorDialog({
   };
 
   const addHarvestInterval = () => {
-    if (selectedTasks.includes("수확-선별")) {
-      setSelectedTasks(prev => [...prev, "수확-선별"]);
+    if (selectedTasks.includes("수확")) {
+      setSelectedTasks(prev => [...prev, "수확"]);
     }
   };
 

--- a/FarmMate/client/src/components/work-calculator-dialog.tsx
+++ b/FarmMate/client/src/components/work-calculator-dialog.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { format, addDays } from "date-fns";
 import { ko } from "date-fns/locale";
-import { Calendar as CalendarIcon, Save } from "lucide-react";
+import { Calendar as CalendarIcon, Save, Plus, Calculator } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -11,6 +11,8 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Popover,
   PopoverContent,
@@ -20,207 +22,247 @@ import { Calendar } from "@/components/ui/calendar";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
+import { BATCH_TASK_SCHEDULES, TASK_TYPES } from "@/shared/constants/crops";
 import type { Crop, InsertTask } from "@shared/schema";
 
 interface WorkCalculatorDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  selectedCrops: string[];
-  selectedWork: string;
+  selectedCrop: Crop | null;
   baseDate: string;
-  crops: Crop[];
+  onSave: (tasks: InsertTask[]) => void;
 }
 
-interface WorkSchedule {
-  cropId: string;
-  cropName: string;
-  recommendedDate: string;
-  selectedDate: string;
+interface TaskSchedule {
+  taskType: string;
+  duration: number;
+  startDate: string;
+  endDate: string;
+  description: string;
 }
-
-// 농작업별 권장 간격 (일)
-const WORK_INTERVALS: Record<string, number> = {
-  "파종-정식": 0,
-  "물주기": 1,
-  "비료주기": 7,
-  "약치기": 14,
-  "풀매기": 21,
-  "가지치기": 30,
-  "수확": 60,
-  "토양관리": 7,
-  "병해충방제": 10,
-  "저장-포장": 3,
-  "기타": 0,
-};
 
 export default function WorkCalculatorDialog({ 
   open, 
   onOpenChange, 
-  selectedCrops, 
-  selectedWork, 
-  baseDate, 
-  crops 
+  selectedCrop,
+  baseDate,
+  onSave
 }: WorkCalculatorDialogProps) {
   const { toast } = useToast();
-  const queryClient = useQueryClient();
   
-  const [schedules, setSchedules] = useState<WorkSchedule[]>(() => {
-    const interval = WORK_INTERVALS[selectedWork] || 0;
-    return selectedCrops.map((cropId, index) => {
-      const crop = crops.find(c => c.id === cropId);
-      const recommendedDate = format(
-        addDays(new Date(baseDate), interval + index), 
-        "yyyy-MM-dd"
-      );
-      return {
-        cropId,
-        cropName: crop ? `${crop.category} → ${crop.name} → ${crop.variety}` : '알 수 없는 작물',
-        recommendedDate,
-        selectedDate: recommendedDate,
-      };
+  const [totalDuration, setTotalDuration] = useState(70);
+  const [taskSchedules, setTaskSchedules] = useState<TaskSchedule[]>([]);
+  const [selectedTasks, setSelectedTasks] = useState<string[]>([
+    "이랑준비", "파종", "고르기", "수확-선별", "저장-포장"
+  ]);
+
+  // 선택된 작업에 따라 일정 계산
+  useEffect(() => {
+    if (!baseDate || selectedTasks.length === 0) return;
+
+    const schedules: TaskSchedule[] = [];
+    let currentDate = new Date(baseDate);
+    
+    selectedTasks.forEach((taskType, index) => {
+      const taskInfo = BATCH_TASK_SCHEDULES[taskType as keyof typeof BATCH_TASK_SCHEDULES];
+      if (taskInfo) {
+        const startDate = format(currentDate, "yyyy-MM-dd");
+        const endDate = format(addDays(currentDate, taskInfo.duration - 1), "yyyy-MM-dd");
+        
+        schedules.push({
+          taskType,
+          duration: taskInfo.duration,
+          startDate,
+          endDate,
+          description: taskInfo.description
+        });
+        
+        // 다음 작업 시작일 계산
+        currentDate = addDays(currentDate, taskInfo.duration);
+      }
     });
-  });
 
-  const [calendarOpen, setCalendarOpen] = useState<string | null>(null);
+    setTaskSchedules(schedules);
+    
+    // 총 소요 기간 계산
+    const total = schedules.reduce((sum, schedule) => sum + schedule.duration, 0);
+    setTotalDuration(total);
+  }, [baseDate, selectedTasks]);
 
-  const updateScheduleDate = (cropId: string, newDate: string) => {
-    setSchedules(prev => 
-      prev.map(schedule => 
-        schedule.cropId === cropId 
-          ? { ...schedule, selectedDate: newDate }
-          : schedule
-      )
+  const handleTaskToggle = (taskType: string) => {
+    setSelectedTasks(prev => 
+      prev.includes(taskType)
+        ? prev.filter(t => t !== taskType)
+        : [...prev, taskType]
     );
   };
 
-  const bulkCreateMutation = useMutation({
-    mutationFn: async (tasks: (InsertTask & { title: string })[]) => {
-      const promises = tasks.map(task => 
-        apiRequest("POST", "/api/tasks", task).then(res => res.json())
-      );
-      return Promise.all(promises);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/tasks"] });
+  const handleSave = () => {
+    console.log("Work calculator handleSave called");
+    console.log("Selected tasks:", selectedTasks);
+    console.log("Task schedules:", taskSchedules);
+    
+    if (selectedTasks.length === 0) {
+      console.log("No tasks selected");
       toast({
-        title: "일괄 등록 완료",
-        description: `${schedules.length}개 작물의 ${selectedWork} 일정이 추가되었습니다.`,
-      });
-      onOpenChange(false);
-    },
-    onError: () => {
-      toast({
-        title: "등록 실패",
-        description: "일정 등록 중 오류가 발생했습니다.",
+        title: "작업을 선택해주세요",
         variant: "destructive",
       });
-    },
-  });
+      return;
+    }
 
-  const handleSave = () => {
-    const tasks = schedules.map(schedule => {
-      const crop = crops.find(c => c.id === schedule.cropId);
-      return {
-        title: `${schedule.cropName.split(' → ')[1]} ${selectedWork}`,
-        description: `농작업 계산기를 통해 생성된 ${selectedWork} 일정`,
-        taskType: selectedWork,
-        scheduledDate: schedule.selectedDate,
-        farmId: crop?.farmId || "",
-        cropId: schedule.cropId,
-        userId: "user-1", // 현재 사용자 ID
+    const tasks: InsertTask[] = taskSchedules.map(schedule => {
+      const task = {
+        title: `${selectedCrop?.name || "작물"} ${schedule.taskType}`,
+        description: schedule.description,
+        taskType: schedule.taskType,
+        scheduledDate: schedule.startDate,
+        endDate: schedule.endDate,
+        farmId: selectedCrop?.farmId || "",
+        cropId: selectedCrop?.id || "",
+        userId: "user-1",
       };
+      console.log("Created work calculator task:", task);
+      return task;
     });
-    
-    bulkCreateMutation.mutate(tasks);
+
+    console.log("Total work calculator tasks to save:", tasks.length);
+    onSave(tasks);
+    onOpenChange(false);
+  };
+
+  const addHarvestInterval = () => {
+    if (selectedTasks.includes("수확-선별")) {
+      setSelectedTasks(prev => [...prev, "수확-선별"]);
+    }
   };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>농작업 계산기</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            <Calculator className="w-5 h-5" />
+            농작업 계산기
+          </DialogTitle>
           <p className="text-sm text-gray-600">
-            {selectedWork} 작업의 권장 일정을 확인하고 조정하세요
+            선택된 작물의 농작업 일정을 자동으로 계산합니다
           </p>
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="text-sm text-gray-600 bg-blue-50 p-3 rounded-lg">
-            <p><strong>선택된 농작업:</strong> {selectedWork}</p>
-            <p><strong>기준 날짜:</strong> {format(new Date(baseDate), "yyyy년 MM월 dd일", { locale: ko })}</p>
-            <p><strong>선택된 작물:</strong> {selectedCrops.length}개</p>
+          {/* 작물 정보 */}
+          {selectedCrop && (
+            <div className="bg-blue-50 p-3 rounded-lg">
+              <p className="text-sm font-medium text-blue-900">
+                선택된 작물: {selectedCrop.category} &gt; {selectedCrop.name} &gt; {selectedCrop.variety}
+              </p>
+            </div>
+          )}
+
+          {/* 총 소요 기간 */}
+          <div className="space-y-2">
+            <Label>총 소요 기간</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                value={totalDuration}
+                onChange={(e) => setTotalDuration(Number(e.target.value))}
+                className="w-20"
+              />
+              <span className="text-sm text-gray-600">일</span>
+            </div>
           </div>
 
+          {/* 농작업 선택 */}
+          <div className="space-y-2">
+            <Label>농작업 선택</Label>
+            <div className="grid grid-cols-2 gap-2">
+              {TASK_TYPES.map(taskType => (
+                <button
+                  key={taskType}
+                  type="button"
+                  onClick={() => handleTaskToggle(taskType)}
+                  className={cn(
+                    "p-2 text-sm border rounded transition-colors text-left",
+                    selectedTasks.includes(taskType)
+                      ? 'border-blue-500 bg-blue-50 text-blue-700'
+                      : 'border-gray-200 hover:border-gray-300'
+                  )}
+                >
+                  {taskType}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* 작업 일정 */}
           <div className="space-y-3">
-            {schedules.map((schedule) => (
-              <Card key={schedule.cropId}>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    {schedule.cropName}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="pt-0">
+            <Label>작업 일정</Label>
+            {taskSchedules.map((schedule, index) => (
+              <Card key={index}>
+                <CardContent className="p-3">
                   <div className="flex items-center justify-between">
-                    <div className="text-xs text-gray-500">
-                      권장: {format(new Date(schedule.recommendedDate), "MM/dd", { locale: ko })}
+                    <div className="flex-1">
+                      <div className="font-medium text-sm">{schedule.taskType}</div>
+                      <div className="text-xs text-gray-500">{schedule.duration} 일</div>
                     </div>
-                    <Popover 
-                      open={calendarOpen === schedule.cropId} 
-                      onOpenChange={(open) => setCalendarOpen(open ? schedule.cropId : null)}
-                    >
-                      <PopoverTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className={cn(
-                            "h-8 text-xs font-normal",
-                            schedule.selectedDate !== schedule.recommendedDate && "border-orange-500 bg-orange-50"
-                          )}
-                        >
-                          {format(new Date(schedule.selectedDate), "MM/dd", { locale: ko })}
-                          <CalendarIcon className="ml-2 h-3 w-3" />
-                        </Button>
-                      </PopoverTrigger>
-                      <PopoverContent className="w-auto p-0" align="end">
-                        <Calendar
-                          mode="single"
-                          selected={new Date(schedule.selectedDate)}
-                          onSelect={(date) => {
-                            if (date) {
-                              updateScheduleDate(schedule.cropId, format(date, "yyyy-MM-dd"));
-                              setCalendarOpen(null);
-                            }
-                          }}
-                          disabled={(date) =>
-                            date < new Date(new Date().setHours(0, 0, 0, 0))
-                          }
-                          initialFocus
-                        />
-                      </PopoverContent>
-                    </Popover>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">
+                        {format(new Date(schedule.startDate), "MM/dd", { locale: ko })}
+                      </span>
+                      <CalendarIcon className="w-4 h-4 text-gray-400" />
+                    </div>
                   </div>
                 </CardContent>
               </Card>
             ))}
           </div>
 
-          <div className="flex gap-3 pt-4">
-            <Button 
-              variant="outline" 
-              className="flex-1"
-              onClick={() => onOpenChange(false)}
+          {/* 수확 사이 추가 */}
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={addHarvestInterval}
+              className="text-xs"
             >
-              취소
-            </Button>
-            <Button 
-              className="flex-1"
-              onClick={handleSave}
-              disabled={bulkCreateMutation.isPending}
-            >
-              <Save className="w-4 h-4 mr-2" />
-              {bulkCreateMutation.isPending ? "저장 중..." : `${schedules.length}개 일정 저장`}
+              <Plus className="w-3 h-3 mr-1" />
+              수확 사이를 추가
             </Button>
           </div>
+
+          {/* 재배 종료일 */}
+          {taskSchedules.length > 0 && (
+            <div className="bg-gray-50 p-3 rounded-lg">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">재배 종료</span>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">
+                    {format(addDays(new Date(baseDate), totalDuration), "MM/dd", { locale: ko })}
+                  </span>
+                  <CalendarIcon className="w-4 h-4 text-gray-400" />
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-3 pt-4">
+          <Button 
+            variant="outline" 
+            className="flex-1"
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button 
+            className="flex-1"
+            onClick={handleSave}
+          >
+            <Save className="w-4 h-4 mr-2" />
+            저장하기
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/FarmMate/client/src/features/crop-management/ui/AddCropDialog.tsx
+++ b/FarmMate/client/src/features/crop-management/ui/AddCropDialog.tsx
@@ -166,7 +166,7 @@ export default function AddCropDialog({ open, onOpenChange, crop }: AddCropDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+              <DialogContent className="sm:max-w-[425px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {crop ? "작물 수정하기" : "작물을 선택해 주세요"}
@@ -269,13 +269,15 @@ export default function AddCropDialog({ open, onOpenChange, crop }: AddCropDialo
               )}
             />
 
-            <Button 
-              type="submit" 
-              className="w-full"
-              disabled={createMutation.isPending || updateMutation.isPending || !selectedCrop}
-            >
-              {createMutation.isPending || updateMutation.isPending ? "저장 중..." : "저장하기"}
-            </Button>
+            <div className="sticky bottom-0 bg-white pt-4 border-t">
+              <Button 
+                type="submit" 
+                className="w-full"
+                disabled={createMutation.isPending || updateMutation.isPending || !selectedCrop}
+              >
+                {createMutation.isPending || updateMutation.isPending ? "저장 중..." : "저장하기"}
+              </Button>
+            </div>
           </form>
         </Form>
       </DialogContent>

--- a/FarmMate/client/src/features/farm-management/ui/AddFarmDialog.tsx
+++ b/FarmMate/client/src/features/farm-management/ui/AddFarmDialog.tsx
@@ -122,7 +122,7 @@ export default function AddFarmDialog({ open, onOpenChange, farm }: AddFarmDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+              <DialogContent className="sm:max-w-[425px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {farm ? "농장 수정하기" : "농장을 선택해 주세요"}
@@ -220,13 +220,15 @@ export default function AddFarmDialog({ open, onOpenChange, farm }: AddFarmDialo
               )}
             />
 
-            <Button 
-              type="submit" 
-              className="w-full"
-              disabled={createMutation.isPending || updateMutation.isPending}
-            >
-              {createMutation.isPending || updateMutation.isPending ? "저장 중..." : "저장하기"}
-            </Button>
+            <div className="sticky bottom-0 bg-white pt-4 border-t">
+              <Button 
+                type="submit" 
+                className="w-full"
+                disabled={createMutation.isPending || updateMutation.isPending}
+              >
+                {createMutation.isPending || updateMutation.isPending ? "저장 중..." : "저장하기"}
+              </Button>
+            </div>
           </form>
         </Form>
       </DialogContent>

--- a/FarmMate/client/src/pages/home/ui/HomePage.tsx
+++ b/FarmMate/client/src/pages/home/ui/HomePage.tsx
@@ -8,7 +8,7 @@ import { useTasks } from "@features/task-management";
 import { useCrops } from "@features/crop-management";
 import { getTaskPriority, getTaskColor, getTaskIcon } from "@entities/task/model/utils";
 import { useLocation } from "wouter";
-import AddTaskDialog from "../../../components/add-task-dialog";
+import AddTaskDialog from "../../../components/add-task-dialog-improved";
 
 export default function HomePage() {
   const [currentDate] = useState(new Date());

--- a/FarmMate/client/src/pages/home/ui/HomePage.tsx
+++ b/FarmMate/client/src/pages/home/ui/HomePage.tsx
@@ -11,7 +11,7 @@ import { useLocation } from "wouter";
 import AddTaskDialog from "../../../components/add-task-dialog-improved";
 
 export default function HomePage() {
-  const [currentDate] = useState(new Date());
+  const [currentDate, setCurrentDate] = useState(new Date());
   const [showAddTaskDialog, setShowAddTaskDialog] = useState(false);
   const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0]);
   const [showMonthView, setShowMonthView] = useState(false);
@@ -30,6 +30,34 @@ export default function HomePage() {
 
   const handleAddTaskClick = () => {
     setShowAddTaskDialog(true);
+  };
+
+  const handlePrevious = () => {
+    if (showMonthView) {
+      // 1달 보기에서는 1달씩 이동
+      const newDate = new Date(currentDate);
+      newDate.setMonth(newDate.getMonth() - 1);
+      setCurrentDate(newDate);
+    } else {
+      // 2주 보기에서는 2주씩 이동
+      const newDate = new Date(currentDate);
+      newDate.setDate(newDate.getDate() - 14);
+      setCurrentDate(newDate);
+    }
+  };
+
+  const handleNext = () => {
+    if (showMonthView) {
+      // 1달 보기에서는 1달씩 이동
+      const newDate = new Date(currentDate);
+      newDate.setMonth(newDate.getMonth() + 1);
+      setCurrentDate(newDate);
+    } else {
+      // 2주 보기에서는 2주씩 이동
+      const newDate = new Date(currentDate);
+      newDate.setDate(newDate.getDate() + 14);
+      setCurrentDate(newDate);
+    }
   };
 
   // Get selected date's tasks (기본값은 오늘)
@@ -73,6 +101,23 @@ export default function HomePage() {
   const formatSelectedDate = () => {
     const date = new Date(selectedDate);
     return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+  };
+
+  const formatCurrentPeriod = () => {
+    if (showMonthView) {
+      return `${currentDate.getFullYear()}년 ${currentDate.getMonth() + 1}월`;
+    } else {
+      // 2주 보기에서는 해당 주의 월요일부터 2주간의 범위를 표시
+      const currentDayOfWeek = currentDate.getDay();
+      const daysFromMonday = currentDayOfWeek === 0 ? 6 : currentDayOfWeek - 1;
+      const monday = new Date(currentDate);
+      monday.setDate(currentDate.getDate() - daysFromMonday);
+      
+      const endDate = new Date(monday);
+      endDate.setDate(monday.getDate() + 13);
+      
+      return `${monday.getMonth() + 1}월 ${monday.getDate()}일 - ${endDate.getMonth() + 1}월 ${endDate.getDate()}일`;
+    }
   };
 
   if (tasksLoading) {
@@ -124,10 +169,31 @@ export default function HomePage() {
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-lg flex items-center justify-between">
-              <span className="flex items-center space-x-2">
-                <CalendarIcon className="w-5 h-5" />
-                <span>{showMonthView ? "한 달 플래너" : "이번 주 플래너"}</span>
-              </span>
+              <div className="flex items-center space-x-2">
+                <Button 
+                  variant="ghost" 
+                  size="sm" 
+                  onClick={handlePrevious}
+                  className="p-1 h-8 w-8"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                </Button>
+                <span className="flex items-center space-x-2">
+                  <CalendarIcon className="w-5 h-5" />
+                  <div className="flex flex-col">
+                    <span>{showMonthView ? "한 달 플래너" : "이번 주 플래너"}</span>
+                    <span className="text-sm text-gray-500 font-normal">{formatCurrentPeriod()}</span>
+                  </div>
+                </span>
+                <Button 
+                  variant="ghost" 
+                  size="sm" 
+                  onClick={handleNext}
+                  className="p-1 h-8 w-8"
+                >
+                  <ChevronRight className="w-4 h-4" />
+                </Button>
+              </div>
               <Button 
                 variant="ghost" 
                 size="sm" 

--- a/FarmMate/client/src/pages/home/ui/HomePage.tsx
+++ b/FarmMate/client/src/pages/home/ui/HomePage.tsx
@@ -1,26 +1,39 @@
 import { useState } from "react";
-import { Calendar as CalendarIcon, ChevronRight, Plus, Clock } from "lucide-react";
+import { Calendar as CalendarIcon, ChevronRight, Plus, Clock, ChevronLeft } from "lucide-react";
 import { Button } from "@shared/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@shared/ui/card";
 import { CalendarGrid } from "@widgets/calendar-grid";
+import MonthCalendar from "@widgets/calendar-grid/ui/MonthCalendar";
 import { useTasks } from "@features/task-management";
 import { useCrops } from "@features/crop-management";
 import { getTaskPriority, getTaskColor, getTaskIcon } from "@entities/task/model/utils";
+import { useLocation } from "wouter";
+import AddTaskDialog from "../../../components/add-task-dialog";
 
 export default function HomePage() {
   const [currentDate] = useState(new Date());
+  const [showAddTaskDialog, setShowAddTaskDialog] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0]);
+  const [showMonthView, setShowMonthView] = useState(false);
+  const [, setLocation] = useLocation();
 
   const { data: tasks = [], isLoading: tasksLoading } = useTasks();
   const { data: crops = [] } = useCrops();
 
   const handleDateClick = (dateStr: string) => {
-    // TODO: Navigate to calendar page with selected date
-    console.log("Selected date:", dateStr);
+    setSelectedDate(dateStr);
   };
 
-  // Get today's tasks
-  const today = new Date().toISOString().split('T')[0];
-  const todaysTasks = tasks.filter(task => task.scheduledDate === today);
+  const handleFullViewClick = () => {
+    setShowMonthView(!showMonthView);
+  };
+
+  const handleAddTaskClick = () => {
+    setShowAddTaskDialog(true);
+  };
+
+  // Get selected date's tasks (기본값은 오늘)
+  const selectedDateTasks = tasks.filter(task => task.scheduledDate === selectedDate);
   
   // Get upcoming tasks (next 7 days)
   const upcomingTasks = tasks
@@ -36,7 +49,7 @@ export default function HomePage() {
   // Get overdue tasks
   const overdueTasks = tasks.filter(task => {
     const priority = getTaskPriority(task.scheduledDate);
-    return priority === "overdue" && task.status !== "completed";
+    return priority === "overdue" && task.completed === 0;
   });
 
   const getCropName = (cropId: string | null | undefined) => {
@@ -57,6 +70,11 @@ export default function HomePage() {
     return `${date.getMonth() + 1}월 ${date.getDate()}일`;
   };
 
+  const formatSelectedDate = () => {
+    const date = new Date(selectedDate);
+    return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+  };
+
   if (tasksLoading) {
     return (
       <div className="p-4 space-y-6">
@@ -72,185 +90,219 @@ export default function HomePage() {
   }
 
   return (
-    <div className="p-4 space-y-6">
-      {/* Header */}
-      <div className="text-center">
-        <h1 className="text-xl font-bold text-gray-900 mb-2">FarmMate</h1>
-        <p className="text-gray-600 text-sm">오늘의 농장 활동을 확인해보세요</p>
-      </div>
+    <>
+      <div className="p-4 space-y-6">
+        {/* Header */}
+        <div className="text-center">
+          <h1 className="text-xl font-bold text-gray-900 mb-2">FarmMate</h1>
+          <p className="text-gray-600 text-sm">오늘의 농장 활동을 확인해보세요</p>
+        </div>
 
-      {/* Quick Stats */}
-      <div className="grid grid-cols-3 gap-3">
-        <Card>
-          <CardContent className="p-4 text-center">
-            <div className="text-2xl font-bold text-blue-600">{todaysTasks.length}</div>
-            <div className="text-xs text-gray-600">오늘 작업</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4 text-center">
-            <div className="text-2xl font-bold text-orange-600">{overdueTasks.length}</div>
-            <div className="text-xs text-gray-600">지연 작업</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4 text-center">
-            <div className="text-2xl font-bold text-green-600">{upcomingTasks.length}</div>
-            <div className="text-xs text-gray-600">예정 작업</div>
-          </CardContent>
-        </Card>
-      </div>
+        {/* Quick Stats */}
+        <div className="grid grid-cols-3 gap-3">
+          <Card>
+            <CardContent className="p-4 text-center">
+              <div className="text-2xl font-bold text-blue-600">{selectedDateTasks.length}</div>
+              <div className="text-xs text-gray-600">선택된 날짜 작업</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <div className="text-2xl font-bold text-orange-600">{overdueTasks.length}</div>
+              <div className="text-xs text-gray-600">지연 작업</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 text-center">
+              <div className="text-2xl font-bold text-green-600">{upcomingTasks.length}</div>
+              <div className="text-xs text-gray-600">예정 작업</div>
+            </CardContent>
+          </Card>
+        </div>
 
-      {/* Mini Calendar Planner */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-lg flex items-center justify-between">
-            <span className="flex items-center space-x-2">
-              <CalendarIcon className="w-5 h-5" />
-              <span>이번 주 플래너</span>
-            </span>
-            <Button variant="ghost" size="sm" className="text-primary">
-              <span>전체 보기</span>
-              <ChevronRight className="w-4 h-4 ml-1" />
-            </Button>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-4 pt-0">
-          <div className="max-h-48 overflow-hidden">
-            <CalendarGrid
-              currentDate={currentDate}
-              tasks={tasks}
-              crops={crops}
-              onDateClick={handleDateClick}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Today's Tasks */}
-      {todaysTasks.length > 0 && (
+        {/* Calendar Planner */}
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-lg flex items-center justify-between">
               <span className="flex items-center space-x-2">
-                <Clock className="w-5 h-5" />
-                <span>오늘의 작업</span>
+                <CalendarIcon className="w-5 h-5" />
+                <span>{showMonthView ? "한 달 플래너" : "이번 주 플래너"}</span>
               </span>
-              <Button variant="ghost" size="sm">
-                <Plus className="w-4 h-4" />
+              <Button 
+                variant="ghost" 
+                size="sm" 
+                className="text-primary"
+                onClick={handleFullViewClick}
+              >
+                {showMonthView ? (
+                  <>
+                    <ChevronLeft className="w-4 h-4 mr-1" />
+                    <span>2주 보기</span>
+                  </>
+                ) : (
+                  <>
+                    <span>전체 보기</span>
+                    <ChevronRight className="w-4 h-4 ml-1" />
+                  </>
+                )}
               </Button>
             </CardTitle>
           </CardHeader>
-          <CardContent className="p-4 pt-0 space-y-3">
-            {todaysTasks.map((task) => (
-              <div
-                key={task.id}
-                className="flex items-center justify-between p-3 border border-gray-200 rounded-lg"
-              >
-                <div className="flex items-center space-x-3">
-                  <div className="text-xl">{getTaskIcon(task.taskType)}</div>
-                  <div>
-                    <h4 className="font-medium text-gray-900">
-                      {getCropName(task.cropId)} - {task.taskType}
-                    </h4>
-                    {task.description && (
-                      <p className="text-sm text-gray-600 mt-1">{task.description}</p>
-                    )}
-                  </div>
-                </div>
-                <div className={`text-xs px-2 py-1 rounded-full ${getTaskColor(task.taskType)}`}>
-                  {task.status === 'completed' ? '완료' : 
-                   task.status === 'in_progress' ? '진행중' : '예정'}
-                </div>
-              </div>
-            ))}
+          <CardContent className="p-4 pt-0">
+            <div className="max-h-96 overflow-hidden">
+              {showMonthView ? (
+                <MonthCalendar
+                  currentDate={currentDate}
+                  tasks={tasks}
+                  crops={crops}
+                  onDateClick={handleDateClick}
+                  selectedDate={selectedDate}
+                />
+              ) : (
+                <CalendarGrid
+                  currentDate={currentDate}
+                  tasks={tasks}
+                  crops={crops}
+                  onDateClick={handleDateClick}
+                  selectedDate={selectedDate}
+                />
+              )}
+            </div>
           </CardContent>
         </Card>
-      )}
 
-      {/* Overdue Tasks */}
-      {overdueTasks.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-lg flex items-center space-x-2 text-red-600">
-              <Clock className="w-5 h-5" />
-              <span>지연된 작업</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-4 pt-0 space-y-3">
-            {overdueTasks.map((task) => (
-              <div
-                key={task.id}
-                className="flex items-center justify-between p-3 border border-red-200 bg-red-50 rounded-lg"
-              >
-                <div className="flex items-center space-x-3">
-                  <div className="text-xl">{getTaskIcon(task.taskType)}</div>
-                  <div>
-                    <h4 className="font-medium text-gray-900">
-                      {getCropName(task.cropId)} - {task.taskType}
-                    </h4>
-                    <p className="text-sm text-red-600">
-                      예정일: {formatDisplayDate(task.scheduledDate)}
-                    </p>
-                  </div>
-                </div>
-                <Button variant="outline" size="sm" className="text-red-600 border-red-200">
-                  처리하기
+        {/* Selected Date's Tasks */}
+        {selectedDateTasks.length > 0 && (
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-lg flex items-center justify-between">
+                <span className="flex items-center space-x-2">
+                  <Clock className="w-5 h-5" />
+                  <span>{formatSelectedDate()}의 작업</span>
+                </span>
+                <Button variant="ghost" size="sm" onClick={handleAddTaskClick}>
+                  <Plus className="w-4 h-4" />
                 </Button>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Upcoming Schedule */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-lg flex items-center justify-between">
-            <span>다가오는 일정</span>
-            <Button variant="ghost" size="sm" className="text-primary">
-              <span>더 보기</span>
-              <ChevronRight className="w-4 h-4 ml-1" />
-            </Button>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-4 pt-0">
-          {upcomingTasks.length > 0 ? (
-            <div className="space-y-3">
-              {upcomingTasks.map((task) => (
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-4 pt-0 space-y-3">
+              {selectedDateTasks.map((task) => (
                 <div
                   key={task.id}
                   className="flex items-center justify-between p-3 border border-gray-200 rounded-lg"
                 >
                   <div className="flex items-center space-x-3">
-                    <div className="text-lg">{getTaskIcon(task.taskType)}</div>
+                    <div className="text-xl">{getTaskIcon(task.taskType)}</div>
                     <div>
                       <h4 className="font-medium text-gray-900">
                         {getCropName(task.cropId)} - {task.taskType}
                       </h4>
-                      <p className="text-sm text-gray-600">
-                        {formatDisplayDate(task.scheduledDate)}
-                      </p>
+                      {task.description && (
+                        <p className="text-sm text-gray-600 mt-1">{task.description}</p>
+                      )}
                     </div>
                   </div>
                   <div className={`text-xs px-2 py-1 rounded-full ${getTaskColor(task.taskType)}`}>
-                    {formatDisplayDate(task.scheduledDate)}
+                    {task.completed === 1 ? '완료' : '예정'}
                   </div>
                 </div>
               ))}
-            </div>
-          ) : (
-            <div className="text-center py-8 text-gray-500">
-              <CalendarIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-              <p>다가오는 작업이 없습니다.</p>
-              <Button className="mt-4" size="sm">
-                <Plus className="w-4 h-4 mr-2" />
-                새 작업 추가하기
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Overdue Tasks */}
+        {overdueTasks.length > 0 && (
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-lg flex items-center justify-between">
+                <span className="flex items-center space-x-2 text-red-600">
+                  <Clock className="w-5 h-5" />
+                  <span>지연된 작업</span>
+                </span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-4 pt-0 space-y-3">
+              {overdueTasks.map((task) => (
+                <div
+                  key={task.id}
+                  className="flex items-center justify-between p-3 border border-red-200 bg-red-50 rounded-lg"
+                >
+                  <div className="flex items-center space-x-3">
+                    <div className="text-xl">{getTaskIcon(task.taskType)}</div>
+                    <div>
+                      <h4 className="font-medium text-gray-900">
+                        {getCropName(task.cropId)} - {task.taskType}
+                      </h4>
+                      <p className="text-sm text-red-600">
+                        예정일: {formatDisplayDate(task.scheduledDate)}
+                      </p>
+                    </div>
+                  </div>
+                  <Button variant="outline" size="sm" className="text-red-600 border-red-200">
+                    처리하기
+                  </Button>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Selected Date's Schedule */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-lg flex items-center justify-between">
+              <span>{formatSelectedDate()}의 일정</span>
+              <Button variant="ghost" size="sm" className="text-primary" onClick={handleAddTaskClick}>
+                <Plus className="w-4 h-4" />
               </Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </div>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-4 pt-0">
+            {selectedDateTasks.length > 0 ? (
+              <div className="space-y-3">
+                {selectedDateTasks.map((task) => (
+                  <div
+                    key={task.id}
+                    className="flex items-center justify-between p-3 border border-gray-200 rounded-lg"
+                  >
+                    <div className="flex items-center space-x-3">
+                      <div className="text-lg">{getTaskIcon(task.taskType)}</div>
+                      <div>
+                        <h4 className="font-medium text-gray-900">
+                          {getCropName(task.cropId)} - {task.taskType}
+                        </h4>
+                        <p className="text-sm text-gray-600">
+                          {formatDisplayDate(task.scheduledDate)}
+                        </p>
+                      </div>
+                    </div>
+                    <div className={`text-xs px-2 py-1 rounded-full ${getTaskColor(task.taskType)}`}>
+                      {formatDisplayDate(task.scheduledDate)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-8 text-gray-500">
+                <CalendarIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+                <p>{formatSelectedDate()}에는 예정된 작업이 없습니다.</p>
+                <Button className="mt-4" size="sm" onClick={handleAddTaskClick}>
+                  <Plus className="w-4 h-4 mr-2" />
+                  새 작업 추가하기
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Add Task Dialog */}
+      <AddTaskDialog
+        open={showAddTaskDialog}
+        onOpenChange={setShowAddTaskDialog}
+        selectedDate={selectedDate}
+      />
+    </>
   );
 }

--- a/FarmMate/client/src/shared/constants/crops.ts
+++ b/FarmMate/client/src/shared/constants/crops.ts
@@ -72,8 +72,7 @@ export const CROP_CATEGORIES = [
 ];
 
 export const TASK_TYPES = [
-  "파종", "육묘", "이랑준비", "정식", "풀/병해충/수분 관리", 
-  "고르기", "수확-선별", "저장-포장"
+  "파종", "육묘", "수확-선별"
 ];
 
 // 일괄등록용 농작업 계산기 데이터
@@ -86,28 +85,8 @@ export const BATCH_TASK_SCHEDULES = {
     duration: 20,
     description: "모종을 기르는 작업"
   },
-  "이랑준비": {
-    duration: 10,
-    description: "이랑을 준비하는 작업"
-  },
-  "정식": {
-    duration: 5,
-    description: "모종을 옮겨 심는 작업"
-  },
-  "풀/병해충/수분 관리": {
-    duration: 15,
-    description: "풀매기, 병해충 방제, 물주기"
-  },
-  "고르기": {
-    duration: 20,
-    description: "작물을 고르는 작업"
-  },
   "수확-선별": {
     duration: 20,
     description: "수확과 선별 작업"
-  },
-  "저장-포장": {
-    duration: 10,
-    description: "저장과 포장 작업"
   }
 };

--- a/FarmMate/client/src/shared/constants/crops.ts
+++ b/FarmMate/client/src/shared/constants/crops.ts
@@ -1,0 +1,113 @@
+export const KEY_CROPS = [
+  {
+    category: "배추",
+    name: "미니양배추",
+    variety: "디아라",
+    description: "작은 크기의 양배추로 가정에서 재배하기 좋음"
+  },
+  {
+    category: "배추",
+    name: "미니양배추", 
+    variety: "티아라",
+    description: "티아라 품종의 미니 양배추"
+  },
+  {
+    category: "배추",
+    name: "콜라비",
+    variety: "그린",
+    description: "줄기 부분을 먹는 배추과 채소"
+  },
+  {
+    category: "배추",
+    name: "콜라비",
+    variety: "퍼플",
+    description: "보라색 줄기의 콜라비"
+  },
+  {
+    category: "뿌리채소",
+    name: "당근",
+    variety: "오렌지",
+    description: "주황색 당근"
+  },
+  {
+    category: "뿌리채소", 
+    name: "비트",
+    variety: "레드",
+    description: "붉은색 비트"
+  },
+  {
+    category: "뿌리채소",
+    name: "무",
+    variety: "백무",
+    description: "흰색 무"
+  },
+  {
+    category: "잎채소",
+    name: "상추",
+    variety: "청상추",
+    description: "녹색 상추"
+  },
+  {
+    category: "잎채소",
+    name: "시금치",
+    variety: "일반",
+    description: "영양이 풍부한 시금치"
+  },
+  {
+    category: "과채류",
+    name: "토마토",
+    variety: "체리",
+    description: "작은 체리 토마토"
+  },
+  {
+    category: "과채류",
+    name: "고추",
+    variety: "청양고추",
+    description: "매운 청양고추"
+  }
+];
+
+export const CROP_CATEGORIES = [
+  "배추", "뿌리채소", "잎채소", "과채류", "콩류", "기타"
+];
+
+export const TASK_TYPES = [
+  "파종", "육묘", "이랑준비", "정식", "풀/병해충/수분 관리", 
+  "고르기", "수확-선별", "저장-포장"
+];
+
+// 일괄등록용 농작업 계산기 데이터
+export const BATCH_TASK_SCHEDULES = {
+  "파종": {
+    duration: 10,
+    description: "씨앗을 뿌리는 작업"
+  },
+  "육묘": {
+    duration: 20,
+    description: "모종을 기르는 작업"
+  },
+  "이랑준비": {
+    duration: 10,
+    description: "이랑을 준비하는 작업"
+  },
+  "정식": {
+    duration: 5,
+    description: "모종을 옮겨 심는 작업"
+  },
+  "풀/병해충/수분 관리": {
+    duration: 15,
+    description: "풀매기, 병해충 방제, 물주기"
+  },
+  "고르기": {
+    duration: 20,
+    description: "작물을 고르는 작업"
+  },
+  "수확-선별": {
+    duration: 20,
+    description: "수확과 선별 작업"
+  },
+  "저장-포장": {
+    duration: 10,
+    description: "저장과 포장 작업"
+  }
+};

--- a/FarmMate/client/src/shared/constants/crops.ts
+++ b/FarmMate/client/src/shared/constants/crops.ts
@@ -72,7 +72,7 @@ export const CROP_CATEGORIES = [
 ];
 
 export const TASK_TYPES = [
-  "파종", "육묘", "수확-선별"
+  "파종", "육묘", "수확"
 ];
 
 // 일괄등록용 농작업 계산기 데이터
@@ -85,7 +85,7 @@ export const BATCH_TASK_SCHEDULES = {
     duration: 20,
     description: "모종을 기르는 작업"
   },
-  "수확-선별": {
+  "수확": {
     duration: 20,
     description: "수확과 선별 작업"
   }

--- a/FarmMate/client/src/widgets/calendar-grid/model/calendar.utils.ts
+++ b/FarmMate/client/src/widgets/calendar-grid/model/calendar.utils.ts
@@ -36,15 +36,15 @@ export const getCropName = (crops: Crop[], cropId: string | null | undefined) =>
 };
 
 export const getCalendarDays = (currentDate: Date): CalendarDay[] => {
-  // 한국 시간대를 고려하여 오늘 날짜 계산
-  const today = new Date();
+  // currentDate 기준으로 해당 주의 월요일을 찾기
+  const baseDate = new Date(currentDate);
   
   // 이번 주의 월요일을 찾기
-  const currentDayOfWeek = today.getDay(); // 0: 일요일, 1: 월요일, ..., 6: 토요일
+  const currentDayOfWeek = baseDate.getDay(); // 0: 일요일, 1: 월요일, ..., 6: 토요일
   const daysFromMonday = currentDayOfWeek === 0 ? 6 : currentDayOfWeek - 1; // 월요일까지의 일수
   
-  const monday = new Date(today);
-  monday.setDate(today.getDate() - daysFromMonday);
+  const monday = new Date(baseDate);
+  monday.setDate(baseDate.getDate() - daysFromMonday);
   
   // 월요일부터 2주간 표시 (14일)
   const days: CalendarDay[] = [];

--- a/FarmMate/client/src/widgets/calendar-grid/model/calendar.utils.ts
+++ b/FarmMate/client/src/widgets/calendar-grid/model/calendar.utils.ts
@@ -1,6 +1,12 @@
 // Calendar widget utility functions
 import type { Task, Crop } from "@shared/types/schema";
 
+export interface CalendarDay {
+  day: number;
+  date: Date;
+  dayOfWeek: number;
+}
+
 export const getTaskColor = (taskType: string) => {
   switch (taskType) {
     case "파종":
@@ -16,10 +22,10 @@ export const getTaskColor = (taskType: string) => {
   }
 };
 
-export const getTasksForDate = (tasks: Task[], date: Date, day: number) => {
+export const getTasksForDate = (tasks: Task[], date: Date) => {
   const year = date.getFullYear();
   const month = date.getMonth();
-  const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
   return tasks.filter(task => task.scheduledDate === dateStr);
 };
 
@@ -29,28 +35,28 @@ export const getCropName = (crops: Crop[], cropId: string | null | undefined) =>
   return crop ? crop.name : "";
 };
 
-export const isToday = (date: Date, day: number) => {
+export const getCalendarDays = (currentDate: Date): CalendarDay[] => {
+  // 한국 시간대를 고려하여 오늘 날짜 계산
   const today = new Date();
-  return (
-    today.getDate() === day &&
-    today.getMonth() === date.getMonth() &&
-    today.getFullYear() === date.getFullYear()
-  );
-};
-
-export const getCalendarDays = (currentDate: Date) => {
-  const today = new Date();
-  const year = today.getFullYear();
-  const month = today.getMonth();
   
-  // 오늘을 기준으로 2주 표시 (14일)
-  const days = [];
+  // 이번 주의 월요일을 찾기
+  const currentDayOfWeek = today.getDay(); // 0: 일요일, 1: 월요일, ..., 6: 토요일
+  const daysFromMonday = currentDayOfWeek === 0 ? 6 : currentDayOfWeek - 1; // 월요일까지의 일수
   
-  // 오늘부터 13일 후까지 (총 14일)
+  const monday = new Date(today);
+  monday.setDate(today.getDate() - daysFromMonday);
+  
+  // 월요일부터 2주간 표시 (14일)
+  const days: CalendarDay[] = [];
+  
   for (let i = 0; i < 14; i++) {
-    const date = new Date(today);
-    date.setDate(today.getDate() + i);
-    days.push(date.getDate());
+    const date = new Date(monday);
+    date.setDate(monday.getDate() + i);
+    days.push({
+      day: date.getDate(),
+      date: date,
+      dayOfWeek: date.getDay() // 0: 일요일, 1: 월요일, ..., 6: 토요일
+    });
   }
   
   return days;

--- a/FarmMate/client/src/widgets/calendar-grid/model/calendar.utils.ts
+++ b/FarmMate/client/src/widgets/calendar-grid/model/calendar.utils.ts
@@ -39,26 +39,18 @@ export const isToday = (date: Date, day: number) => {
 };
 
 export const getCalendarDays = (currentDate: Date) => {
-  const year = currentDate.getFullYear();
-  const month = currentDate.getMonth();
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
   
-  // Get first day of month and number of days
-  const firstDay = new Date(year, month, 1);
-  const lastDay = new Date(year, month + 1, 0);
-  const daysInMonth = lastDay.getDate();
-  const startingDay = firstDay.getDay();
-  
-  // Create calendar grid
+  // 오늘을 기준으로 2주 표시 (14일)
   const days = [];
   
-  // Add empty cells for days before month starts
-  for (let i = 0; i < (startingDay === 0 ? 6 : startingDay - 1); i++) {
-    days.push(null);
-  }
-  
-  // Add days of month
-  for (let day = 1; day <= daysInMonth; day++) {
-    days.push(day);
+  // 오늘부터 13일 후까지 (총 14일)
+  for (let i = 0; i < 14; i++) {
+    const date = new Date(today);
+    date.setDate(today.getDate() + i);
+    days.push(date.getDate());
   }
   
   return days;

--- a/FarmMate/client/src/widgets/calendar-grid/ui/CalendarGrid.tsx
+++ b/FarmMate/client/src/widgets/calendar-grid/ui/CalendarGrid.tsx
@@ -3,9 +3,9 @@ import {
   getTaskColor, 
   getTasksForDate, 
   getCropName, 
-  isToday,
   getCalendarDays,
-  weekDays 
+  weekDays,
+  type CalendarDay
 } from "../model/calendar.utils";
 
 interface CalendarGridProps {
@@ -18,25 +18,29 @@ interface CalendarGridProps {
 
 export default function CalendarGrid({ currentDate, tasks, crops, onDateClick, selectedDate }: CalendarGridProps) {
   const days = getCalendarDays(currentDate);
+  const today = new Date();
 
   return (
     <div className="grid grid-cols-7 gap-2">
       {/* Week Headers */}
-      {weekDays.map(day => (
+      {weekDays.map((day: string) => (
         <div key={day} className="text-center py-2 text-xs font-medium text-gray-600">
           {day}
         </div>
       ))}
 
       {/* Calendar Days */}
-      {days.map((day, index) => {
-        const today = new Date();
-        const currentDay = new Date(today);
-        currentDay.setDate(today.getDate() + index);
+      {days.map((dayInfo: CalendarDay, index: number) => {
+        const { day, date } = dayInfo;
+        const dayTasks = getTasksForDate(tasks, date);
         
-        const dayTasks = getTasksForDate(tasks, currentDay, day);
-        const todayCheck = index === 0; // 첫 번째 날이 오늘
-        const isSelected = selectedDate === currentDay.toISOString().split('T')[0];
+        // 오늘 날짜인지 확인
+        const todayCheck = 
+          today.getDate() === date.getDate() &&
+          today.getMonth() === date.getMonth() &&
+          today.getFullYear() === date.getFullYear();
+          
+        const isSelected = selectedDate === date.toISOString().split('T')[0];
 
         return (
           <div
@@ -45,7 +49,7 @@ export default function CalendarGrid({ currentDate, tasks, crops, onDateClick, s
               todayCheck ? 'bg-primary/5 border-primary' : ''
             } ${isSelected ? 'bg-blue-50 border-blue-300' : ''} ${dayTasks.length > 0 ? 'bg-gray-50' : ''}`}
             onClick={() => {
-              const dateStr = `${currentDay.getFullYear()}-${String(currentDay.getMonth() + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+              const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
               onDateClick(dateStr);
             }}
           >
@@ -55,7 +59,7 @@ export default function CalendarGrid({ currentDate, tasks, crops, onDateClick, s
             {/* 기본적으로는 작업 개수만 표시, 선택된 날짜일 때만 상세 내용 표시 */}
             {isSelected && dayTasks.length > 0 ? (
               <div className="space-y-0.5">
-                {dayTasks.slice(0, 2).map(task => (
+                {dayTasks.slice(0, 2).map((task: Task) => (
                   <div
                     key={task.id}
                     className={`text-xs px-1 py-0.5 rounded truncate ${getTaskColor(task.taskType)}`}

--- a/FarmMate/client/src/widgets/calendar-grid/ui/CalendarGrid.tsx
+++ b/FarmMate/client/src/widgets/calendar-grid/ui/CalendarGrid.tsx
@@ -13,59 +13,68 @@ interface CalendarGridProps {
   tasks: Task[];
   crops: Crop[];
   onDateClick: (date: string) => void;
+  selectedDate?: string;
 }
 
-export default function CalendarGrid({ currentDate, tasks, crops, onDateClick }: CalendarGridProps) {
+export default function CalendarGrid({ currentDate, tasks, crops, onDateClick, selectedDate }: CalendarGridProps) {
   const days = getCalendarDays(currentDate);
 
   return (
-    <div className="grid grid-cols-7 gap-4">
+    <div className="grid grid-cols-7 gap-2">
       {/* Week Headers */}
       {weekDays.map(day => (
-        <div key={day} className="text-center py-3 text-sm font-medium text-gray-600">
+        <div key={day} className="text-center py-2 text-xs font-medium text-gray-600">
           {day}
         </div>
       ))}
 
       {/* Calendar Days */}
       {days.map((day, index) => {
-        if (day === null) {
-          return <div key={index} className="min-h-24"></div>;
-        }
-
-        const dayTasks = getTasksForDate(tasks, currentDate, day);
-        const todayCheck = isToday(currentDate, day);
+        const today = new Date();
+        const currentDay = new Date(today);
+        currentDay.setDate(today.getDate() + index);
+        
+        const dayTasks = getTasksForDate(tasks, currentDay, day);
+        const todayCheck = index === 0; // 첫 번째 날이 오늘
+        const isSelected = selectedDate === currentDay.toISOString().split('T')[0];
 
         return (
           <div
-            key={day}
-            className={`min-h-24 p-2 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-50 ${
+            key={index}
+            className={`min-h-20 p-1 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-50 transition-colors ${
               todayCheck ? 'bg-primary/5 border-primary' : ''
-            } ${dayTasks.length > 0 ? 'bg-gray-50' : ''}`}
+            } ${isSelected ? 'bg-blue-50 border-blue-300' : ''} ${dayTasks.length > 0 ? 'bg-gray-50' : ''}`}
             onClick={() => {
-              const dateStr = `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+              const dateStr = `${currentDay.getFullYear()}-${String(currentDay.getMonth() + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
               onDateClick(dateStr);
             }}
           >
             <div className={`text-xs mb-1 ${todayCheck ? 'font-bold text-primary' : 'text-gray-900'}`}>
               {day}
             </div>
-            <div className="space-y-1">
-              {dayTasks.slice(0, 2).map(task => (
-                <div
-                  key={task.id}
-                  className={`text-xs px-1 py-0.5 rounded truncate ${getTaskColor(task.taskType)}`}
-                  title={`${getCropName(crops, task.cropId)} - ${task.taskType}`}
-                >
-                  {getCropName(crops, task.cropId)} {task.taskType}
-                </div>
-              ))}
-              {dayTasks.length > 2 && (
-                <div className="text-xs text-gray-500">
-                  +{dayTasks.length - 2}개 더
-                </div>
-              )}
-            </div>
+            {/* 기본적으로는 작업 개수만 표시, 선택된 날짜일 때만 상세 내용 표시 */}
+            {isSelected && dayTasks.length > 0 ? (
+              <div className="space-y-0.5">
+                {dayTasks.slice(0, 2).map(task => (
+                  <div
+                    key={task.id}
+                    className={`text-xs px-1 py-0.5 rounded truncate ${getTaskColor(task.taskType)}`}
+                    title={`${getCropName(crops, task.cropId)} - ${task.taskType}`}
+                  >
+                    {getCropName(crops, task.cropId)} {task.taskType}
+                  </div>
+                ))}
+                {dayTasks.length > 2 && (
+                  <div className="text-xs text-gray-500">
+                    +{dayTasks.length - 2}개
+                  </div>
+                )}
+              </div>
+            ) : dayTasks.length > 0 ? (
+              <div className="text-xs text-gray-500 text-center">
+                {dayTasks.length}개
+              </div>
+            ) : null}
           </div>
         );
       })}

--- a/FarmMate/client/src/widgets/calendar-grid/ui/MonthCalendar.tsx
+++ b/FarmMate/client/src/widgets/calendar-grid/ui/MonthCalendar.tsx
@@ -3,7 +3,6 @@ import {
   getTaskColor, 
   getTasksForDate, 
   getCropName, 
-  isToday,
   weekDays 
 } from "../model/calendar.utils";
 
@@ -65,8 +64,15 @@ export default function MonthCalendar({ currentDate, tasks, crops, onDateClick, 
         }
 
         const currentDate = new Date(year, month, day);
-        const dayTasks = getTasksForDate(tasks, currentDate, day);
-        const todayCheck = isToday(currentDate, day);
+        const dayTasks = getTasksForDate(tasks, currentDate);
+        
+        // 오늘 날짜인지 확인
+        const today = new Date();
+        const todayCheck = 
+          today.getDate() === day &&
+          today.getMonth() === month &&
+          today.getFullYear() === year;
+          
         const isSelected = selectedDate === currentDate.toISOString().split('T')[0];
         const isCurrentMonth = currentDate.getMonth() === month;
 

--- a/FarmMate/client/src/widgets/calendar-grid/ui/MonthCalendar.tsx
+++ b/FarmMate/client/src/widgets/calendar-grid/ui/MonthCalendar.tsx
@@ -1,0 +1,100 @@
+import type { Task, Crop } from "@shared/types/schema";
+import { 
+  getTaskColor, 
+  getTasksForDate, 
+  getCropName, 
+  isToday,
+  weekDays 
+} from "../model/calendar.utils";
+
+interface MonthCalendarProps {
+  currentDate: Date;
+  tasks: Task[];
+  crops: Crop[];
+  onDateClick: (date: string) => void;
+  selectedDate?: string;
+}
+
+export default function MonthCalendar({ currentDate, tasks, crops, onDateClick, selectedDate }: MonthCalendarProps) {
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+  
+  // 해당 월의 첫 번째 날과 마지막 날
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const daysInMonth = lastDay.getDate();
+  const startingDay = firstDay.getDay();
+  
+  // 주의 시작을 월요일로 설정 (0: 일요일, 1: 월요일)
+  const adjustedStartingDay = startingDay === 0 ? 6 : startingDay - 1;
+  
+  // 캘린더 그리드 생성
+  const days = [];
+  
+  // 이전 달의 마지막 날들
+  for (let i = 0; i < adjustedStartingDay; i++) {
+    days.push(null);
+  }
+  
+  // 현재 달의 날들
+  for (let day = 1; day <= daysInMonth; day++) {
+    days.push(day);
+  }
+  
+  // 다음 달의 첫 번째 날들 (7의 배수로 맞추기)
+  const remainingDays = 7 - (days.length % 7);
+  if (remainingDays < 7) {
+    for (let i = 0; i < remainingDays; i++) {
+      days.push(null);
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-7 gap-1">
+      {/* 요일 헤더 */}
+      {weekDays.map(day => (
+        <div key={day} className="text-center py-2 text-sm font-medium text-gray-600">
+          {day}
+        </div>
+      ))}
+
+      {/* 날짜 그리드 */}
+      {days.map((day, index) => {
+        if (day === null) {
+          return <div key={index} className="min-h-16"></div>;
+        }
+
+        const currentDate = new Date(year, month, day);
+        const dayTasks = getTasksForDate(tasks, currentDate, day);
+        const todayCheck = isToday(currentDate, day);
+        const isSelected = selectedDate === currentDate.toISOString().split('T')[0];
+        const isCurrentMonth = currentDate.getMonth() === month;
+
+        return (
+          <div
+            key={index}
+            className={`min-h-16 p-1 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-50 transition-colors ${
+              !isCurrentMonth ? 'text-gray-400' : ''
+            } ${todayCheck ? 'bg-primary/5 border-primary' : ''} ${
+              isSelected ? 'bg-blue-50 border-blue-300' : ''
+            } ${dayTasks.length > 0 ? 'bg-gray-50' : ''}`}
+            onClick={() => {
+              const dateStr = `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+              onDateClick(dateStr);
+            }}
+          >
+            <div className={`text-xs mb-1 ${todayCheck ? 'font-bold text-primary' : ''}`}>
+              {day}
+            </div>
+            {/* 작업이 있는 경우 개수만 표시 */}
+            {dayTasks.length > 0 && (
+              <div className="text-xs text-gray-500 text-center">
+                {dayTasks.length}개
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/FarmMate/package.json
+++ b/FarmMate/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "concurrently --kill-others --prefix=\"[{name}]\" --names=\"client,server\" \"C:\\\\Users\\\\바이오헬스\\\\.bun\\\\bin\\\\bun.exe run dev:client\" \"C:\\\\Users\\\\바이오헬스\\\\.bun\\\\bin\\\\bun.exe run dev:server\"",
     "dev:client": "vite --host localhost --port 3000",
-    "dev:server": "cross-env TMPDIR=./tmp TEMP=./tmp TMP=./tmp NODE_ENV=development tsx server/index.ts",
+    "dev:server": "cross-env NODE_ENV=development TMPDIR=./tmp TEMP=./tmp TMP=./tmp tsx server/index.ts",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/FarmMate/package.json
+++ b/FarmMate/package.json
@@ -4,10 +4,9 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "concurrently --kill-others --prefix=\"[{name}]\" --names=\"client,server\" \"npm run dev:client\" \"npm run dev:server\"",
+    "dev": "concurrently --kill-others --prefix=\"[{name}]\" --names=\"client,server\" \"C:\\\\Users\\\\바이오헬스\\\\.bun\\\\bin\\\\bun.exe run dev:client\" \"C:\\\\Users\\\\바이오헬스\\\\.bun\\\\bin\\\\bun.exe run dev:server\"",
     "dev:client": "vite --host localhost --port 3000",
-    "dev:server": "NODE_ENV=development tsx --tsconfig tsconfig.json server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "dev:server": "cross-env TMPDIR=./tmp TEMP=./tmp TMP=./tmp NODE_ENV=development tsx server/index.ts",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
@@ -86,6 +85,7 @@
     "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
     "concurrently": "^9.2.0",
+    "cross-env": "^10.0.0",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
     "postcss": "^8.4.47",

--- a/FarmMate/server/index.ts
+++ b/FarmMate/server/index.ts
@@ -118,17 +118,21 @@ process.on('SIGINT', () => gracefulShutdown('SIGINT'));
       });
     });
 
-    // ALWAYS serve the app on the port specified in the environment variable PORT
-    // Other ports are firewalled. Default to 5000 if not specified.
-    // this serves both the API and the client.
-    // It is the only port that is not firewalled.
-    const port = parseInt(process.env.PORT || '5000', 10);
+    // Development: Use port 5000 for API server
+    // Production: Use environment PORT or default to 5000
+    const port = isProduction 
+      ? parseInt(process.env.PORT || '5000', 10)
+      : 5000;
     
     server.listen({
       port,
       host: "localhost",
     }, () => {
       log(`Server successfully started on port ${port} in ${process.env.NODE_ENV} mode`);
+      if (!isProduction) {
+        log(`Frontend development server available at: http://localhost:3000`);
+        log(`API server available at: http://localhost:${port}`);
+      }
       log('Application initialization completed successfully');
       
       // Signal that the app is ready (helpful for deployment systems)

--- a/FarmMate/server/vite.ts
+++ b/FarmMate/server/vite.ts
@@ -22,7 +22,11 @@ export function log(message: string, source = "express") {
 export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
-    hmr: { server },
+    hmr: { 
+      server,
+      port: 3000,
+      host: 'localhost'
+    },
     allowedHosts: true as const,
   };
 
@@ -33,7 +37,10 @@ export async function setupVite(app: Express, server: Server) {
       ...viteLogger,
       error: (msg, options) => {
         viteLogger.error(msg, options);
-        process.exit(1);
+        // Don't exit in development mode
+        if (process.env.NODE_ENV === 'production') {
+          process.exit(1);
+        }
       },
     },
     server: serverOptions,

--- a/FarmMate/vite.config.ts
+++ b/FarmMate/vite.config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
+    host: "0.0.0.0",
+    port: 3000,
+    strictPort: true,
     fs: {
       strict: true,
       deny: ["**/.*"],

--- a/tatus
+++ b/tatus
@@ -1,0 +1,10 @@
+[33m66eb27fe[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mhyeonuk[m[33m, [m[1;31morigin/hyeonuk[m[33m)[m 홈화면 새 작업 추가하기 기능 수정 및 taskTypes 간소화
+[33mfdbc62c9[m 작업 내용 요약
+[33m2158e0f1[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mmain[m[33m)[m fix: dev:server 스크립트에 tsconfig 경로 추가
+[33m7e32c40b[m feat: Improve dev script to properly handle Ctrl+C signal
+[33mf4a24ffb[m gitignore: 새 .gitignore 파일 추가
+[33m58c3f2cf[m docs: Update README with comprehensive FarmMate documentation
+[33m2bbca7b3[m remove node modules
+[33mf98c0b05[m feat: Add refactored FarmMate project with FSD architecture
+[33m9a454dff[m Add FarmMate file only
+[33m938cda94[m Merge branch 'main' of https://github.com/Ryoo1128/python-vegelab-calendar


### PR DESCRIPTION
[1차]
이번주 플래너 2주 표시
오늘을 기준으로 2주(14일)를 표시하도록 변경
셀 크기를 줄이고 간격을 조정하여 2주가 잘 보이도록 개선전체보기 버튼 클릭 가능
전체보기 버튼 클릭 가능
"다가오는 일정" → "오늘의 일정" 변경
제목을 "오늘의 일정"으로 변경하고 괄호 안에 오늘 날짜 표시 (예: "오늘의 일정 (12월 15일)")
 더보기 버튼 → + 모양 버튼
새 작업 추가하기 플로우
재배환경 선택 (노지, 시설1, 시설2)
농장 번호 입력
작물 검색 및 선택
농작업 선택 (파종, 육묘, 정식 등)
작업 날짜 선택
메모 입력 (선택사항)
[2차]
새 작업 추가하기 저장 기능[[저장 안됨]] [[실패]]
전체보기 → 한 달 캘린더
전체보기 버튼 클릭 시 2주 보기와 한 달 보기 전환
날짜별 클릭 시 오늘의 일정 변경